### PR TITLE
feature/mc-9850 - Changes to password reset form

### DIFF
--- a/src/app/pages/forgot-password/forgot-password.component.html
+++ b/src/app/pages/forgot-password/forgot-password.component.html
@@ -38,7 +38,7 @@ SPDX-License-Identifier: Apache-2.0
   actionLabel="Return to Sign-in"
   actionRouterLink="/sign-in"
 >
-  <p>
+  <p class="password-reset-message">
     We've sent an email to your email address with a link to reset your password. To
     create your new password, please follow the link in the email. If you don't see an
     email from us within a few minutes, check your spam folder and the email address you

--- a/src/app/pages/forgot-password/forgot-password.component.scss
+++ b/src/app/pages/forgot-password/forgot-password.component.scss
@@ -16,3 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
+
+.password-reset-message {
+  text-align: justify;
+}

--- a/src/app/security/forgot-password-form/forgot-password-form.component.html
+++ b/src/app/security/forgot-password-form/forgot-password-form.component.html
@@ -35,7 +35,7 @@ SPDX-License-Identifier: Apache-2.0
         <mat-error *ngIf="email?.errors?.pattern"> Invalid email address </mat-error>
       </mat-form-field>
     </div>
-    <div class="form-submit">
+    <div class="form-submit mdm-password-reset-confirmation">
       <button
         type="submit"
         (click)="resetPassword()"

--- a/src/app/security/forgot-password-form/forgot-password-form.component.scss
+++ b/src/app/security/forgot-password-form/forgot-password-form.component.scss
@@ -21,3 +21,6 @@ SPDX-License-Identifier: Apache-2.0
     text-align: right;
   }
 }
+.mdm-password-reset-confirmation {
+  margin: 0 0 5px 0;
+}


### PR DESCRIPTION
- Justified the reset info box for alignment with the return link
- narrowed the padding between the email field and the submit button to look more like the wireframes and make it look 'narrower'