### PR TITLE
gh-143 Add global error handler to catch app init errors

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -30,7 +30,6 @@ import { SecurityService } from './security/security.service';
 import { UserDetails, UserDetailsService } from './security/user-details.service';
 import { FooterLink } from './shared/footer/footer.component';
 import { HeaderImageLink, HeaderLink } from './shared/header/header.component';
-import { OverlayContainer } from '@angular/cdk/overlay';
 import { UserIdleService } from './external/user-idle.service';
 
 @Component({
@@ -40,8 +39,6 @@ import { UserIdleService } from './external/user-idle.service';
 })
 export class AppComponent implements OnInit, OnDestroy {
   title = 'mdm-explorer';
-
-  themeCssSelector = 'default-theme';
 
   isLoading = false;
   loadingCaption = '';
@@ -164,8 +161,7 @@ export class AppComponent implements OnInit, OnDestroy {
     private stateRouter: StateRouterService,
     private toastr: ToastrService,
     private userIdle: UserIdleService,
-    private error: ErrorService,
-    private overlayContainer: OverlayContainer
+    private error: ErrorService
   ) {}
 
   @HostListener('window:mousemove', ['$event'])
@@ -174,8 +170,6 @@ export class AppComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.setTheme();
-
     this.broadcast
       .on<HttpErrorResponse>('http-application-offline')
       .pipe(takeUntil(this.unsubscribe$))
@@ -339,12 +333,5 @@ export class AppComponent implements OnInit, OnDestroy {
         this.toastr.info('Your session has expired! Please sign in.');
         this.signOutUser();
       });
-  }
-
-  private setTheme() {
-    // Material theme is wrapped inside a CSS class but the overlay container is not part of Angular
-    // Material. Have to manually set the correct theme class to this container too
-    this.overlayContainer.getContainerElement().classList.add(this.themeCssSelector);
-    this.overlayContainer.getContainerElement().classList.add('overlay-container');
   }
 }

--- a/src/app/core/app-error-dialog/app-error-dialog.component.html
+++ b/src/app/core/app-error-dialog/app-error-dialog.component.html
@@ -1,0 +1,34 @@
+<!--
+Copyright 2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+<div>
+  <h1>Application error</h1>
+  <div mat-dialog-content>
+    <p>
+      We're sorry, but this application encountered an error which prevents it from
+      operating.
+    </p>
+    <p *ngIf="error.message" class="error-message">
+      {{ error.message }}
+    </p>
+    <p>
+      Attempt to rectify the error (or contact your administrator), then reload this page
+      to try again.
+    </p>
+  </div>
+</div>

--- a/src/app/core/app-error-dialog/app-error-dialog.component.scss
+++ b/src/app/core/app-error-dialog/app-error-dialog.component.scss
@@ -1,0 +1,25 @@
+/*
+Copyright 2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+.error-message {
+  background: #eee;
+  padding: 1rem;
+  font-family: monospace;
+  word-break: break-all;
+  white-space: pre-line;
+}

--- a/src/app/core/app-error-dialog/app-error-dialog.component.spec.ts
+++ b/src/app/core/app-error-dialog/app-error-dialog.component.spec.ts
@@ -1,0 +1,44 @@
+/*
+Copyright 2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import {
+  ComponentHarness,
+  setupTestModuleForComponent,
+} from 'src/app/testing/testing.helpers';
+
+import { AppErrorDialogComponent } from './app-error-dialog.component';
+
+describe('AppErrorDialogComponent', () => {
+  let harness: ComponentHarness<AppErrorDialogComponent>;
+
+  beforeEach(async () => {
+    harness = await setupTestModuleForComponent(AppErrorDialogComponent, {
+      providers: [
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: {},
+        },
+      ],
+    });
+  });
+
+  it('should create', () => {
+    expect(harness.isComponentCreated).toBeTruthy();
+  });
+});

--- a/src/app/core/app-error-dialog/app-error-dialog.component.ts
+++ b/src/app/core/app-error-dialog/app-error-dialog.component.ts
@@ -1,0 +1,39 @@
+/*
+Copyright 2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Component, Inject, OnInit } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+export interface AppErrorDialogData {
+  error: any;
+}
+
+@Component({
+  selector: 'mdm-app-error-dialog',
+  templateUrl: './app-error-dialog.component.html',
+  styleUrls: ['./app-error-dialog.component.scss'],
+})
+export class AppErrorDialogComponent implements OnInit {
+  error: any;
+
+  constructor(@Inject(MAT_DIALOG_DATA) private data: AppErrorDialogData) {}
+
+  ngOnInit(): void {
+    this.error = this.data.error;
+  }
+}

--- a/src/app/core/app-error-handler.service.spec.ts
+++ b/src/app/core/app-error-handler.service.spec.ts
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { MatDialog } from '@angular/material/dialog';
+import { createMatDialogStub } from '../testing/stubs/mat-dialog.stub';
+import { setupTestModuleForService } from '../testing/testing.helpers';
+import { AppErrorHandlerService } from './app-error-handler.service';
+
+describe('AppErrorHandlerService', () => {
+  let service: AppErrorHandlerService;
+  const dialogStub = createMatDialogStub();
+
+  beforeEach(() => {
+    service = setupTestModuleForService(AppErrorHandlerService, {
+      providers: [
+        {
+          provide: MatDialog,
+          useValue: dialogStub,
+        },
+      ],
+    });
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/core/app-error-handler.service.ts
+++ b/src/app/core/app-error-handler.service.ts
@@ -1,0 +1,47 @@
+/*
+Copyright 2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { ErrorHandler, Injectable } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { AppErrorDialogComponent } from './app-error-dialog/app-error-dialog.component';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AppErrorHandlerService implements ErrorHandler {
+  constructor(private dialog: MatDialog) {}
+
+  handleError(error: any): void {
+    if (!error) {
+      return;
+    }
+
+    if (error.rejection) {
+      // Get the reason why the error happened
+      error = error.rejection;
+    }
+
+    this.dialog.open(AppErrorDialogComponent, {
+      data: {
+        error,
+      },
+      disableClose: true,
+      hasBackdrop: true,
+    });
+  }
+}

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { NgModule } from '@angular/core';
+import { ErrorHandler, NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -38,6 +38,9 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatPasswordStrengthModule } from '@angular-material-extensions/password-strength';
+import { AppErrorHandlerService } from './app-error-handler.service';
+import { AppErrorDialogComponent } from './app-error-dialog/app-error-dialog.component';
+import { OverlayContainer } from '@angular/cdk/overlay';
 
 const angularModules = [CommonModule, FormsModule, ReactiveFormsModule, RouterModule];
 const primeNgModules = [CarouselModule];
@@ -63,8 +66,23 @@ const materialModules = [
 ];
 
 @NgModule({
-  declarations: [],
+  declarations: [AppErrorDialogComponent],
   imports: [...angularModules, ...materialModules, ...primeNgModules],
   exports: [...angularModules, ...materialModules, ...primeNgModules],
+  providers: [
+    {
+      provide: ErrorHandler,
+      useClass: AppErrorHandlerService,
+    },
+  ],
 })
-export class CoreModule {}
+export class CoreModule {
+  themeCssSelector = 'default-theme';
+
+  constructor(overlayContainer: OverlayContainer) {
+    // Material theme is wrapped inside a CSS class but the overlay container is not part of Angular
+    // Material. Have to manually set the correct theme class to this container too
+    overlayContainer.getContainerElement().classList.add(this.themeCssSelector);
+    overlayContainer.getContainerElement().classList.add('overlay-container');
+  }
+}

--- a/src/app/data-explorer/data-explorer.service.ts
+++ b/src/app/data-explorer/data-explorer.service.ts
@@ -84,12 +84,18 @@ export class DataExplorerService {
           !explorerProps.profileNamespace ||
           !explorerProps.profileServiceName
         ) {
-          return throwError(
-            () =>
-              new Error(
-                `Cannot find all configuration keys in Mauro API properties. Check all required properties are listed under the '${configurationKeys.category}' section and have values.`
-              )
-          );
+          return throwError(() => {
+            const lines = [
+              'Cannot find all configuration keys in Mauro API properties',
+              `Check all required properties are listed under the '${configurationKeys.category}' section and have values.`,
+              'The following API properties are required:',
+              '\n',
+              configurationKeys.profileNamespace,
+              configurationKeys.profileServiceName,
+              configurationKeys.rootDataModelPath,
+            ];
+            return new Error(lines.join('\n'));
+          });
         }
 
         this.config = {


### PR DESCRIPTION
Resolves #143 

* Display dialog full screen if something critically goes wrong
* Update CoreModule to configure OverlayContainer css classes in shared area

Example of the error handler in use when a missing API property is found:

![image](https://user-images.githubusercontent.com/3219480/174624118-cf456408-7778-41ff-8304-d327ec930f17.png)
