### PR TITLE
gh-170 Adjustments to query builder controls

### DIFF
--- a/src/app/data-explorer/querybuilder/querybuilder.component.html
+++ b/src/app/data-explorer/querybuilder/querybuilder.component.html
@@ -129,11 +129,15 @@ SPDX-License-Identifier: Apache-2.0
       </ng-container>
       <!-- Boolean -->
       <ng-container *queryInput="let rule; type: 'boolean'; let onChange = onChange">
-        <mat-checkbox
-          [color]="color"
-          [(ngModel)]="rule.value"
-          (ngModelChange)="onChange()"
-        ></mat-checkbox>
+        <mat-form-field
+          appearance="outline"
+          class="query-builder-input mat-form-field-no-padding"
+        >
+          <mat-select [(ngModel)]="rule.value" (ngModelChange)="onChange()">
+            <mat-option [value]="false">False</mat-option>
+            <mat-option [value]="true">True</mat-option>
+          </mat-select>
+        </mat-form-field>
       </ng-container>
       <!-- Category -->
       <ng-container

--- a/src/app/data-explorer/querybuilder/querybuilder.component.scss
+++ b/src/app/data-explorer/querybuilder/querybuilder.component.scss
@@ -24,17 +24,15 @@ SPDX-License-Identifier: Apache-2.0
 
 /* Set the query builder controls lengths. */
 .query-builder-field {
-  width: 400px !important;
+  width: 40%;
 }
 
 .query-builder-operator {
-  width: 160px !important;
+  width: 10%;
+  min-width: 120px;
 }
 
-.query-builder-input {
-  width: 300px !important;
-}
-
+.query-builder-input,
 .query-builder-number {
-  width: 150px !important;
+  width: 30%;
 }


### PR DESCRIPTION
- Change widths of query field controls to use percentages
- Change query builder boolean option to a select control

Resolves #170 

Can only set percentages for control widths because the query builder library component controls the container which all controls are in, there is no template available to change that. Also, the Angular Material mat-select is not able to have an autosized width based on content in the option list.

![image](https://user-images.githubusercontent.com/3219480/208663202-e11230fb-734d-4eaa-b1fb-cffc6c639d18.png)
