### PR TITLE
gh-155 Improve pagination control on smaller screen widths

### DIFF
--- a/src/app/data-explorer/data-explorer.module.ts
+++ b/src/app/data-explorer/data-explorer.module.ts
@@ -84,7 +84,7 @@ import { MeqlOutputComponent } from './meql-output/meql-output.component';
       provide: PAGINATION_CONFIG,
       useValue: {
         defaultPageSize: 10,
-        maxPagesToShow: 10,
+        maxPagesToShow: 5,
       },
     },
   ],

--- a/src/app/data-explorer/pagination/pagination.component.html
+++ b/src/app/data-explorer/pagination/pagination.component.html
@@ -67,7 +67,4 @@ SPDX-License-Identifier: Apache-2.0
       <span class="fa-solid fa-angles-right"></span>
     </button>
   </li>
-  <li class="page-item page-counter">
-    <span title="{{ totalPages }} pages">[ {{ totalPages }} ]</span>
-  </li>
 </ul>

--- a/src/app/data-explorer/pagination/pagination.component.html
+++ b/src/app/data-explorer/pagination/pagination.component.html
@@ -20,6 +20,7 @@ SPDX-License-Identifier: Apache-2.0
   *ngIf="pages && pages.length > 0"
   class="pagination justify-content-end mdm-pagination"
 >
+  <li class="page-item page-counter">{{ currentPage }} of {{ totalPages }}</li>
   <li [ngClass]="{ disabled: currentPage === 1 }" class="page-item first-item">
     <button
       class="page-link"

--- a/src/app/data-explorer/pagination/pagination.component.scss
+++ b/src/app/data-explorer/pagination/pagination.component.scss
@@ -33,11 +33,11 @@ $pager-font-weight: 600;
     margin: 0 4px;
   }
 
-  // li.page-counter {
-  //   padding: 0.375rem 0.75rem;
-  //   color: $pager-color;
-  //   font-weight: $pager-font-weight;
-  // }
+  li.page-counter {
+    padding: 0.375rem 0.75rem;
+    color: $pager-color;
+    font-weight: $pager-font-weight;
+  }
 
   button.page-link {
     font-weight: $pager-font-weight;

--- a/src/app/data-explorer/pagination/pagination.component.scss
+++ b/src/app/data-explorer/pagination/pagination.component.scss
@@ -33,11 +33,11 @@ $pager-font-weight: 600;
     margin: 0 4px;
   }
 
-  li.page-counter {
-    padding: 0.375rem 0.75rem;
-    color: $pager-color;
-    font-weight: $pager-font-weight;
-  }
+  // li.page-counter {
+  //   padding: 0.375rem 0.75rem;
+  //   color: $pager-color;
+  //   font-weight: $pager-font-weight;
+  // }
 
   button.page-link {
     font-weight: $pager-font-weight;

--- a/src/app/pages/search-listing/search-listing.component.html
+++ b/src/app/pages/search-listing/search-listing.component.html
@@ -86,21 +86,23 @@ SPDX-License-Identifier: Apache-2.0
           (bookmark)="bookmarkElement($event)"
           [sourceTargetIntersections]="sourceTargetIntersections"
         ></mdm-data-element-search-result>
-        <ng-container *ngIf="resultSet.totalResults > 0">
-          <div class="float-start">
-            <mat-checkbox (change)="onSelectAll($event)">Select all</mat-checkbox>
-            <mdm-data-element-multi-select
-              [sourceTargetIntersections]="sourceTargetIntersections"
-              [dataElements]="selectedElements"
-            ></mdm-data-element-multi-select>
-          </div>
-        </ng-container>
-        <mdm-pagination
-          [currentPage]="resultSet.page"
-          [pageSize]="resultSet.pageSize"
-          [totalResults]="resultSet.totalResults"
-          (selected)="selectPage($event)"
-        ></mdm-pagination>
+        <div class="mdm-search-listing__footer-row">
+          <ng-container *ngIf="resultSet.totalResults > 0">
+            <div class="float-start">
+              <mat-checkbox (change)="onSelectAll($event)">Select all</mat-checkbox>
+              <mdm-data-element-multi-select
+                [sourceTargetIntersections]="sourceTargetIntersections"
+                [dataElements]="selectedElements"
+              ></mdm-data-element-multi-select>
+            </div>
+          </ng-container>
+          <mdm-pagination
+            [currentPage]="resultSet.page"
+            [pageSize]="resultSet.pageSize"
+            [totalResults]="resultSet.totalResults"
+            (selected)="selectPage($event)"
+          ></mdm-pagination>
+        </div>
         <div *ngIf="resultSet.totalResults === 0" class="mdm-search-listing__no-results">
           <p>Unfortunately we could not find any matches based on this criteria. Try:</p>
           <ul>

--- a/src/app/pages/search-listing/search-listing.component.scss
+++ b/src/app/pages/search-listing/search-listing.component.scss
@@ -71,4 +71,11 @@ $no-results-background-color: $color-mauro-light-gold;
     padding: 2em 3em;
     border-radius: 4px;
   }
+
+  &__footer-row {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 1em;
+  }
 }


### PR DESCRIPTION
- Reduce number of page numbers to display
- Use flexbox container to forces select and page controls to wrap when screen width is too small
- Remove total number of pages count from pagination component, seems superfluous

Fixes #155 

# Screenshots

Large screen width:

![image](https://user-images.githubusercontent.com/3219480/208889029-839a1c84-67e2-48fa-b193-0ccafaa2b578.png)

Small screen width:

![image](https://user-images.githubusercontent.com/3219480/208888968-8d2b05f2-2b67-4650-be07-3016255d3544.png)
