### PR TITLE
gh-171: Query Builder field type mapping management

### DIFF
--- a/src/app/data-explorer/querybuilder/querybuilder.component.html
+++ b/src/app/data-explorer/querybuilder/querybuilder.component.html
@@ -53,6 +53,7 @@ SPDX-License-Identifier: Apache-2.0
           [color]="color"
           *ngIf="addRuleSet"
           (click)="addRuleSet()"
+          [disabled]="noValidFields"
         >
           <mat-icon>add_circle_outline</mat-icon>
           Rule Set
@@ -64,6 +65,7 @@ SPDX-License-Identifier: Apache-2.0
           [color]="color"
           *ngIf="removeRuleSet"
           (click)="removeRuleSet()"
+          [disabled]="noValidFields"
         >
           <mat-icon>remove_circle_outline</mat-icon>
         </button>

--- a/src/app/data-explorer/querybuilder/querybuilder.component.spec.ts
+++ b/src/app/data-explorer/querybuilder/querybuilder.component.spec.ts
@@ -16,28 +16,37 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MeqlPipe } from '../pipes/meql.pipe';
-
 import { QueryBuilderComponent } from './querybuilder.component';
+import { MdmResourcesConfiguration } from '@maurodatamapper/mdm-resources';
+import { MeqlPipe } from '../pipes/meql.pipe';
+import {
+  ComponentHarness,
+  setupTestModuleForComponent,
+} from 'src/app/testing/testing.helpers';
 
 describe('QueryBuilderComponent', () => {
-  let component: QueryBuilderComponent;
-  let fixture: ComponentFixture<QueryBuilderComponent>;
+  let harness: ComponentHarness<QueryBuilderComponent>;
+  const mdmResourcesConfiguration = new MdmResourcesConfiguration();
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [QueryBuilderComponent, MeqlPipe],
-    }).compileComponents();
-  });
+  const setupComponentTest = async () => {
+    return await setupTestModuleForComponent(QueryBuilderComponent, {
+      providers: [
+        {
+          provide: MdmResourcesConfiguration,
+          useValue: mdmResourcesConfiguration,
+        },
+      ],
+      declarations: [MeqlPipe],
+    });
+  };
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(QueryBuilderComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+  describe('creation', () => {
+    beforeEach(async () => {
+      harness = await setupComponentTest();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+    it('should be created', () => {
+      expect(harness.component).toBeTruthy();
+    });
   });
 });

--- a/src/app/data-explorer/querybuilder/querybuilder.component.ts
+++ b/src/app/data-explorer/querybuilder/querybuilder.component.ts
@@ -19,9 +19,8 @@ SPDX-License-Identifier: Apache-2.0
 /*
 Query builder source: https://github.com/zebzhao/Angular-QueryBuilder
 */
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { QueryBuilderConfig, RuleSet } from 'angular2-query-builder';
-import { DataType } from '@maurodatamapper/mdm-resources';
 import {
   DataElementSearchResult,
   QueryCondition,
@@ -33,19 +32,18 @@ import { ThemePalette } from '@angular/material/core';
   templateUrl: './querybuilder.component.html',
   styleUrls: ['./querybuilder.component.scss'],
 })
-export class QueryBuilderComponent implements OnInit {
+export class QueryBuilderComponent {
   @Input() dataElements: DataElementSearchResult[] = [];
   @Input() color: ThemePalette = 'primary';
   @Input() query: QueryCondition = {
     condition: 'and',
     rules: [],
   };
-
-  @Output() queryChange = new EventEmitter<QueryCondition>();
-
-  config: QueryBuilderConfig = {
+  @Input() config: QueryBuilderConfig = {
     fields: {},
   };
+
+  @Output() queryChange = new EventEmitter<QueryCondition>();
 
   operatorMap: { [key: string]: string[] } = {
     /* eslint-disable-next-line */
@@ -54,128 +52,11 @@ export class QueryBuilderComponent implements OnInit {
 
   allowRuleset = true;
 
-  ngOnInit(): void {
-    this.setupConfig();
+  get noValidFields(): boolean {
+    return Object.keys(this.config.fields).length === 0;
   }
 
   modelChanged(value: RuleSet) {
     this.queryChange.emit(value as QueryCondition);
-  }
-
-  private queryBuilderDataType(dataType?: DataType) {
-    if (dataType?.enumerationValues?.length ?? 0 > 0) {
-      return 'category';
-    }
-
-    // This should not be hard coded and managed elsewhere. gh-171 has been raised to address this.
-    switch (dataType?.label?.toLowerCase()) {
-      // strings
-      case 'char':
-      case 'char[n]':
-      case 'nchar':
-      case 'ntext':
-      case 'nvarchar':
-      case 'nvarchar[max]':
-      case 'string':
-      case 'text':
-      case 'varbinary[max]':
-      case 'varchar':
-      case 'varchar[max]':
-      case 'varchar[n]':
-      case 'xml': {
-        return 'string';
-      }
-      // numbers
-      case 'bigint':
-      case 'datetimeoffset':
-      case 'decimal':
-      case 'decimal[p,s]':
-      case 'float':
-      case 'float[n]':
-      case 'int':
-      case 'integer':
-      case 'money':
-      case 'numeric':
-      case 'numeric[p,s]':
-      case 'real':
-      case 'smallint':
-      case 'smallmoney':
-      case 'timestamp':
-      case 'tinyint': {
-        return 'number';
-      }
-      // dates
-      case 'date':
-      case 'datetime':
-      case 'datetime2':
-      case 'smalldatetime': {
-        return 'date';
-      }
-      // time
-      case 'time': {
-        return 'time';
-      }
-      // boolean
-      case 'bit':
-      case 'boolean': {
-        return 'boolean';
-      }
-      // unsupported
-      case 'binary':
-      case 'binary[n]':
-      case 'cursor':
-      case 'Finalised Data Type':
-      case 'image':
-      case 'sql_variant':
-      case 'table':
-      case 'uniqueidentifier':
-      case 'V1 Data Type':
-      case 'V2 Data Type 2':
-      case 'V2 Data Type 3':
-      case 'V2 Data Type':
-      case 'varbinary': {
-        return 'unsupported';
-      }
-      default:
-        return 'string';
-    }
-  }
-
-  private getDefaultValue(dataType: DataType | undefined) {
-    const dataTypeString = this.queryBuilderDataType(dataType);
-    if (dataTypeString.toLowerCase() === 'number') {
-      return 0;
-    } else {
-      return null;
-    }
-  }
-
-  private setupConfig() {
-    const sortedDataElements: DataElementSearchResult[] = this.dataElements.sort(
-      (n1, n2) => n1.label.localeCompare(n2.label)
-    );
-
-    // Reinitialise the object so that the screen will update.
-    this.config = {
-      fields: {},
-    };
-
-    // Setup the config
-    sortedDataElements.forEach((dataElement) => {
-      const dataTypeString = this.queryBuilderDataType(dataElement.dataType);
-      if (dataTypeString !== 'unsupported') {
-        this.config.fields[dataElement.label] = {
-          name: dataElement.label + ' (' + dataTypeString + ')',
-          type: dataTypeString,
-          options: (dataElement.dataType?.enumerationValues ?? []).map((dataOption) => {
-            return {
-              name: dataOption.key,
-              value: dataOption.value,
-            };
-          }),
-          defaultValue: this.getDefaultValue(dataElement.dataType),
-        };
-      }
-    });
   }
 }

--- a/src/app/mauro/profile.service.ts
+++ b/src/app/mauro/profile.service.ts
@@ -28,6 +28,7 @@ import {
   ProfileSearchResponse,
   ProfileDefinition,
   ProfileDefinitionResponse,
+  RequestSettings,
 } from '@maurodatamapper/mdm-resources';
 import { map, Observable } from 'rxjs';
 import { MdmEndpointsService } from '../mauro/mdm-endpoints.service';
@@ -54,10 +55,11 @@ export class ProfileService {
     catalogueItemDomainType: CatalogueItemDomainType,
     catalogueItemId: Uuid,
     profileNamespace: string,
-    profileName: string
+    profileName: string,
+    options?: RequestSettings,
   ): Observable<Profile> {
     return this.endpoints.profile
-      .profile(catalogueItemDomainType, catalogueItemId, profileNamespace, profileName)
+      .profile(catalogueItemDomainType, catalogueItemId, profileNamespace, profileName, undefined, undefined, options)
       .pipe(map((response: Profile) => response.body));
   }
 

--- a/src/app/mauro/query-builder.service.spec.ts
+++ b/src/app/mauro/query-builder.service.spec.ts
@@ -417,7 +417,7 @@ describe('QueryBuilderService', () => {
             ? '(a|)'
             : '---(a|)',
           {
-            a: [expectedResult],
+            a: expectedResult,
           }
         );
         const actual$ = service.setupConfig(

--- a/src/app/mauro/query-builder.service.spec.ts
+++ b/src/app/mauro/query-builder.service.spec.ts
@@ -1,0 +1,430 @@
+/*
+Copyright 2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import {
+  CatalogueItemDomainType,
+  DataType,
+  MdmResourcesConfiguration,
+  Profile,
+} from '@maurodatamapper/mdm-resources';
+import { cold } from 'jest-marbles';
+import { setupTestModuleForService } from '../testing/testing.helpers';
+import { ProfileService } from './profile.service';
+import { QueryBuilderService } from './query-builder.service';
+import {
+  DataElementSearchResult,
+  DataRequestQueryPayload,
+} from '../data-explorer/data-explorer.types';
+import { QueryBuilderConfig } from 'angular2-query-builder';
+import { createProfileServiceStub } from '../testing/stubs/profile.stub';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of } from 'rxjs';
+
+const defaultCatalogueItemDomainType = CatalogueItemDomainType.PrimitiveType;
+const defaultProfileNamespace =
+  'uk.ac.ox.softeng.maurodatamapper.plugins.explorer.querybuilder';
+const defaultProfileServiceName = 'QueryBuilderPrimitiveTypeProfileProviderService';
+
+abstract class testHelper {
+  public static expectedProfilesStubGet = (
+    actualCatalogueItemDomainType: CatalogueItemDomainType,
+    actualCatalogueItemId: string,
+    actualProfileNamespace: string,
+    actualProfileName: string,
+    expectedCatalogueItemId: string
+  ) => {
+    expect(actualCatalogueItemDomainType).toBe(defaultCatalogueItemDomainType);
+    expect(actualCatalogueItemId).toBe(expectedCatalogueItemId);
+    expect(actualProfileNamespace).toBe(defaultProfileNamespace);
+    expect(actualProfileName).toBe(defaultProfileServiceName);
+  };
+
+  public static createMappingProfile = (
+    dataType: DataType,
+    currentValue: string,
+    domainType: CatalogueItemDomainType = CatalogueItemDomainType.PrimitiveType
+  ): Profile => {
+    return {
+      sections: [
+        {
+          name: 'section1',
+          fields: [
+            {
+              fieldName: 'QueryBuilderType',
+              metadataPropertyName: 'querybuildertype',
+              dataType: 'enumeration',
+              currentValue,
+            },
+          ],
+        },
+      ],
+      id: dataType.Id ?? '',
+      label: dataType.label,
+      domainType,
+    };
+  };
+
+  public static dataType_varchar: DataType = {
+    id: 'dt-varchar',
+    domainType: defaultCatalogueItemDomainType,
+    label: 'varchar',
+  };
+
+  public static dataType_int: DataType = {
+    id: 'dt-int',
+    domainType: defaultCatalogueItemDomainType,
+    label: 'int',
+  };
+
+  public static dataType_bool: DataType = {
+    id: 'dt-bool',
+    domainType: defaultCatalogueItemDomainType,
+    label: 'bool',
+  };
+
+  public static dataType_date: DataType = {
+    id: 'dt-date',
+    domainType: defaultCatalogueItemDomainType,
+    label: 'date',
+  };
+
+  public static dataType_time: DataType = {
+    id: 'dt-time',
+    domainType: defaultCatalogueItemDomainType,
+    label: 'time',
+  };
+
+  public static dataType_enumeration: DataType = {
+    id: 'dt-enum',
+    domainType: defaultCatalogueItemDomainType,
+    label: 'enum_type',
+    enumerationValues: [
+      { index: 0, key: 'Option 1', value: 'Option 1' },
+      { index: 1, key: 'Option 2', value: 'Option 2' },
+    ],
+  };
+
+  public static dataType_nonPrimitive: DataType = {
+    id: 'dt-time',
+    domainType: CatalogueItemDomainType.ReferenceType,
+    label: 'time',
+  };
+
+  public static getProfile(profiles: Profile[], dataTypeLabel: string): DataType {
+    const result = profiles.find((i) => i.label === dataTypeLabel) ?? ({} as DataType);
+
+    if (Object.keys(result).length === 0) {
+      const error = new HttpErrorResponse({
+        error: new Error('404 Not Found'),
+        status: 404,
+      });
+      return of(error) as any;
+    }
+    return result;
+  }
+}
+
+describe('QueryBuilderService', () => {
+  let service: QueryBuilderService;
+  const profilesStub = createProfileServiceStub();
+
+  beforeEach(() => {
+    service = setupTestModuleForService(QueryBuilderService, {
+      providers: [
+        {
+          provide: ProfileService,
+          useValue: profilesStub,
+        },
+        {
+          provide: MdmResourcesConfiguration,
+          useValue: {},
+        },
+      ],
+    });
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('setup config', () => {
+    /* =======================================================================================================*/
+    /*
+      Number, String, Boolean, Date, Time, Category
+    */
+    it.each<[string, DataType, string | undefined, boolean, string | undefined]>([
+      [
+        'finds string when varchar mapped to string',
+        testHelper.dataType_varchar,
+        'string',
+        false,
+        'string',
+      ],
+      [
+        'finds nothing when varchar unmapped',
+        testHelper.dataType_varchar,
+        undefined,
+        false,
+        undefined,
+      ],
+      [
+        'finds string when varchar unmapped but referenced in query',
+        testHelper.dataType_varchar,
+        undefined,
+        true,
+        'string',
+      ],
+      [
+        'finds number when int mapped to number',
+        testHelper.dataType_int,
+        'number',
+        false,
+        'number',
+      ],
+      [
+        'finds string when int unmapped',
+        testHelper.dataType_int,
+        undefined,
+        false,
+        undefined,
+      ],
+      [
+        'finds string when int unmapped but referenced in query',
+        testHelper.dataType_int,
+        undefined,
+        true,
+        'string',
+      ],
+      [
+        'finds category when enumeration mapped to something',
+        testHelper.dataType_enumeration,
+        'string',
+        false,
+        'category',
+      ],
+      [
+        'finds category when enumeration unmapped',
+        testHelper.dataType_enumeration,
+        undefined,
+        false,
+        'category',
+      ],
+      [
+        'finds category when enumeration unmapped but referenced in query',
+        testHelper.dataType_enumeration,
+        undefined,
+        true,
+        'category',
+      ],
+      [
+        'finds boolean when bool mapped to boolean',
+        testHelper.dataType_bool,
+        'boolean',
+        false,
+        'boolean',
+      ],
+      [
+        'finds nothing when bool unmapped',
+        testHelper.dataType_bool,
+        undefined,
+        false,
+        undefined,
+      ],
+      [
+        'finds string when bool unmapped but referenced in query',
+        testHelper.dataType_bool,
+        undefined,
+        true,
+        'string',
+      ],
+      [
+        'finds date when date mapped to date',
+        testHelper.dataType_date,
+        'date',
+        false,
+        'date',
+      ],
+      [
+        'finds nothing when date unmapped',
+        testHelper.dataType_date,
+        undefined,
+        false,
+        undefined,
+      ],
+      [
+        'finds string when date unmapped but referenced in query',
+        testHelper.dataType_date,
+        undefined,
+        true,
+        'string',
+      ],
+      [
+        'finds time when varchar mapped to string',
+        testHelper.dataType_time,
+        'time',
+        false,
+        'time',
+      ],
+      [
+        'finds nothing when varchar unmapped',
+        testHelper.dataType_time,
+        undefined,
+        false,
+        undefined,
+      ],
+      [
+        'finds string when varchar unmapped but referenced in query',
+        testHelper.dataType_time,
+        undefined,
+        true,
+        'string',
+      ],
+      [
+        'finds nothing when non primitive type mapped to string',
+        testHelper.dataType_nonPrimitive,
+        'string',
+        false,
+        undefined,
+      ],
+      [
+        'finds nothing when non primitive type unmapped',
+        testHelper.dataType_nonPrimitive,
+        undefined,
+        false,
+        undefined,
+      ],
+      [
+        'finds string when non primitive type unmapped but referenced in query',
+        testHelper.dataType_nonPrimitive,
+        undefined,
+        true,
+        'string',
+      ],
+    ])(
+      '%s',
+      (testname, dataType, mappedType, isReferencedInQuery, expectedMappedType) => {
+        const isMapped = mappedType !== undefined;
+
+        const expectedDataElementSearchResult: DataElementSearchResult[] = [
+          {
+            id: 'f-1',
+            label: 'field',
+            dataType,
+          } as DataElementSearchResult,
+        ];
+
+        const expectedQuery: DataRequestQueryPayload | undefined = isReferencedInQuery
+          ? ({
+              condition: {
+                condition: 'and',
+                rules: [
+                  {
+                    field: `field (${expectedMappedType})`,
+                    operator: '=',
+                    value: 'value-1',
+                  },
+                ],
+              },
+            } as DataRequestQueryPayload)
+          : undefined;
+
+        const expectedQueryBuilderConfig: QueryBuilderConfig = {
+          fields:
+            expectedMappedType !== undefined
+              ? {
+                  field: {
+                    defaultValue:
+                      expectedMappedType === 'number'
+                        ? 0
+                        : expectedMappedType === 'string'
+                        ? ''
+                        : expectedMappedType === 'boolean'
+                        ? false
+                        : null,
+                    name: `field (${expectedMappedType})`,
+                    options:
+                      expectedMappedType === 'category'
+                        ? [
+                            { name: 'Option 1', value: 'Option 1' },
+                            { name: 'Option 2', value: 'Option 2' },
+                          ]
+                        : [],
+                    type: expectedMappedType,
+                  },
+                }
+              : ({} as any),
+        };
+
+        const profiles: Profile[] = isMapped
+          ? dataType.domainType !== CatalogueItemDomainType.PrimitiveType
+            ? [testHelper.createMappingProfile(dataType, mappedType)]
+            : [
+                testHelper.createMappingProfile(
+                  dataType,
+                  mappedType,
+                  CatalogueItemDomainType.ReferenceType
+                ),
+              ]
+          : [];
+
+        const mockProfile = (profile: Profile[]) => {
+          profilesStub.get.mockImplementationOnce(
+            (catalogueItemDomainType, catalogueItemId, profileNamespace, profileName) => {
+              testHelper.expectedProfilesStubGet(
+                catalogueItemDomainType,
+                catalogueItemId,
+                profileNamespace,
+                profileName,
+                dataType.id ?? ''
+              );
+              return cold(
+                dataType.domainType !== CatalogueItemDomainType.PrimitiveType
+                  ? 'a|'
+                  : '--a|',
+                {
+                  a: testHelper.getProfile(profile, dataType.label),
+                }
+              );
+            }
+          );
+        };
+
+        mockProfile(profiles);
+
+        const expected$ = cold(
+          dataType.domainType !== CatalogueItemDomainType.PrimitiveType
+            ? '(a|)'
+            : '---(a|)',
+          {
+            a: [
+              expectedDataElementSearchResult,
+              expectedQuery,
+              expectedQueryBuilderConfig,
+            ],
+          }
+        );
+        const actual$ = service.setupConfig(
+          expectedDataElementSearchResult,
+          expectedQuery
+        );
+
+        expect(actual$).toBeObservable(expected$);
+      }
+    );
+  });
+});

--- a/src/app/mauro/query-builder.service.spec.ts
+++ b/src/app/mauro/query-builder.service.spec.ts
@@ -25,7 +25,7 @@ import {
 import { cold } from 'jest-marbles';
 import { setupTestModuleForService } from '../testing/testing.helpers';
 import { ProfileService } from './profile.service';
-import { QueryBuilderService } from './query-builder.service';
+import { QueryBuilderService, QueryConfiguration } from './query-builder.service';
 import {
   DataElementSearchResult,
   DataRequestQueryPayload,
@@ -404,6 +404,12 @@ describe('QueryBuilderService', () => {
           );
         };
 
+        const expectedResult: QueryConfiguration = {
+          dataElementSearchResult: expectedDataElementSearchResult,
+          dataRequestQueryPayload: expectedQuery as Required<DataRequestQueryPayload>,
+          config: expectedQueryBuilderConfig,
+        };
+
         mockProfile(profiles);
 
         const expected$ = cold(
@@ -411,11 +417,7 @@ describe('QueryBuilderService', () => {
             ? '(a|)'
             : '---(a|)',
           {
-            a: [
-              expectedDataElementSearchResult,
-              expectedQuery,
-              expectedQueryBuilderConfig,
-            ],
+            a: [expectedResult],
           }
         );
         const actual$ = service.setupConfig(

--- a/src/app/mauro/query-builder.service.ts
+++ b/src/app/mauro/query-builder.service.ts
@@ -47,7 +47,7 @@ export class QueryBuilderService {
   public setupConfig(
     dataElements: DataElementSearchResult[],
     query?: DataRequestQueryPayload
-  ): Observable<[QueryConfiguration]> {
+  ): Observable<QueryConfiguration> {
     const requests$ = dataElements.map((dataElement) => {
       const profile$ = this.getQueryBuilderDatatype(dataElement.dataType).pipe(
         catchError((error) => {
@@ -66,7 +66,7 @@ export class QueryBuilderService {
 
     return forkJoin(requests$).pipe(
       map((items) => {
-        return [this.getQueryFields(items, dataElements, query)];
+        return this.getQueryFields(items, dataElements, query);
       })
     );
   }

--- a/src/app/mauro/query-builder.service.ts
+++ b/src/app/mauro/query-builder.service.ts
@@ -1,0 +1,145 @@
+/*
+Copyright 2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Injectable } from '@angular/core';
+import {
+  CatalogueItemDomainType,
+  DataType,
+  Profile,
+} from '@maurodatamapper/mdm-resources';
+import { QueryBuilderConfig } from 'angular2-query-builder';
+import { catchError, forkJoin, map, Observable, of } from 'rxjs';
+import {
+  DataElementSearchResult,
+  DataRequestQueryPayload,
+  QueryExpression,
+} from '../data-explorer/data-explorer.types';
+import { ProfileService } from './profile.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class QueryBuilderService {
+  constructor(private profileService: ProfileService) {}
+
+  private getQueryBuilderDatatype(dataType?: DataType): Observable<Profile> {
+    if (dataType?.domainType === CatalogueItemDomainType.PrimitiveType) {
+      const requestOptions = {
+        handleGetErrors: false,
+      };
+
+      return this.profileService.get(
+        CatalogueItemDomainType.PrimitiveType,
+        dataType?.id ?? '',
+        'uk.ac.ox.softeng.maurodatamapper.plugins.explorer.querybuilder',
+        'QueryBuilderPrimitiveTypeProfileProviderService',
+        requestOptions
+      );
+    }
+    return of({} as Profile);
+  }
+
+  public setupConfig(
+    dataElements: DataElementSearchResult[],
+    query?: DataRequestQueryPayload
+  ): Observable<
+    [
+      DataElementSearchResult[],
+      Required<DataRequestQueryPayload> | undefined,
+      QueryBuilderConfig
+    ]
+  > {
+    const requests$ = dataElements.map((dataElement) => {
+      const profile$ = this.getQueryBuilderDatatype(dataElement.dataType).pipe(
+        catchError((error) => {
+          if (error.status === 404) {
+            return of({} as Profile);
+          }
+
+          throw error;
+        })
+      );
+
+      const dataElement$ = of(dataElement);
+
+      return forkJoin([profile$, dataElement$]);
+    });
+
+    return forkJoin(requests$).pipe(
+      map((items) => {
+        const queryCondition = query
+          ? query.condition
+          : {
+              condition: 'and',
+              rules: [],
+            };
+
+        const config: QueryBuilderConfig = {
+          fields: {},
+        };
+
+        items.forEach(([data, dataElement]) => {
+          const dataTypeString =
+            dataElement.dataType?.enumerationValues?.length ?? 0 > 0
+              ? 'category'
+              : data?.sections?.length > 0
+              ? data.sections[0].fields[0].currentValue
+              : undefined;
+
+          if (dataTypeString) {
+            config.fields[dataElement.label] = {
+              name: dataElement.label + ' (' + dataTypeString + ')',
+              type: dataTypeString,
+              options: (dataElement.dataType?.enumerationValues ?? []).map(
+                (dataOption) => {
+                  return {
+                    name: dataOption.key,
+                    value: dataOption.value,
+                  };
+                }
+              ),
+              defaultValue:
+                dataTypeString.toLowerCase() === 'number'
+                  ? 0
+                  : dataTypeString.toLowerCase() === 'string'
+                  ? ''
+                  : dataTypeString.toLowerCase() === 'boolean'
+                  ? false
+                  : null,
+            };
+          } else {
+            if (
+              queryCondition?.rules?.find((x) =>
+                (x as QueryExpression)?.field?.startsWith(dataElement.label)
+              )
+            ) {
+              config.fields[dataElement.label] = {
+                name: dataElement.label + ' (string)',
+                type: 'string',
+                options: [],
+                defaultValue: '',
+              };
+            }
+          }
+        });
+
+        return [dataElements, query as Required<DataRequestQueryPayload>, config];
+      })
+    );
+  }
+}

--- a/src/app/pages/request-query/request-query.component.html
+++ b/src/app/pages/request-query/request-query.component.html
@@ -62,6 +62,7 @@ SPDX-License-Identifier: Apache-2.0
       </h2>
       <mdm-querybuilder
         [dataElements]="dataElements"
+        [config]="config"
         [(query)]="condition"
         (queryChange)="onQueryChange($event)"
       ></mdm-querybuilder>

--- a/src/app/pages/request-query/request-query.component.spec.ts
+++ b/src/app/pages/request-query/request-query.component.spec.ts
@@ -21,6 +21,7 @@ import { ActivatedRoute, Params } from '@angular/router';
 import {
   CatalogueItemDomainType,
   DataElement,
+  MdmResourcesConfiguration,
   Uuid,
 } from '@maurodatamapper/mdm-resources';
 import { ToastrService } from 'ngx-toastr';
@@ -51,6 +52,7 @@ describe('RequestQueryComponent', () => {
   const dataRequestsStub = createDataRequestsServiceStub();
   const toastrStub = createToastrServiceStub();
   const broadcastStub = createBroadcastServiceStub();
+  const mdmResourcesConfiguration = new MdmResourcesConfiguration();
 
   const requestId: Uuid = '1234';
 
@@ -79,6 +81,10 @@ describe('RequestQueryComponent', () => {
         {
           provide: BroadcastService,
           useValue: broadcastStub,
+        },
+        {
+          provide: MdmResourcesConfiguration,
+          useValue: mdmResourcesConfiguration,
         },
       ],
     });

--- a/src/app/pages/request-query/request-query.component.ts
+++ b/src/app/pages/request-query/request-query.component.ts
@@ -115,7 +115,7 @@ export class RequestQueryComponent implements OnInit, IModelPage {
           );
         })
       )
-      .subscribe(([queryConfiguration]) => {
+      .subscribe((queryConfiguration) => {
         this.dataElements = queryConfiguration.dataElementSearchResult;
         this.config = queryConfiguration.config;
         this.query = queryConfiguration.dataRequestQueryPayload;

--- a/src/app/pages/request-query/request-query.component.ts
+++ b/src/app/pages/request-query/request-query.component.ts
@@ -115,10 +115,10 @@ export class RequestQueryComponent implements OnInit, IModelPage {
           );
         })
       )
-      .subscribe(([dataElements, query, config]) => {
-        this.dataElements = dataElements;
-        this.config = config;
-        this.query = query;
+      .subscribe(([queryConfiguration]) => {
+        this.dataElements = queryConfiguration.dataElementSearchResult;
+        this.config = queryConfiguration.config;
+        this.query = queryConfiguration.dataRequestQueryPayload;
         this.condition = this.query ? this.query.condition : defaultQueryCondition;
         this.original = JSON.stringify(this.condition);
         this.status = 'ready';


### PR DESCRIPTION
This code is reliant on the code committed in https://github.com/MauroDataMapper-Plugins/mdm-plugin-explorer/pull/13 . 

To test this a profile needs to be created on a data type to map the primitive data type to the query builder data type.

In the MDM UI
1. Go to the list of Data Types.
2. Click on one of the primitive types, e.g: float.
3. On the Description tab in the dropdown select "Add new profile..."
4. Then choose "Mauro Data Explorer - Query Builder Data Type (1.0.0)" and Save Changes
5. On the next screen that appears choose the query builder type you want to associate with the field (e.g: number) and save.

In the MDM Explorer
1. Go to a request (or create a new one) that has a float field included in it.
2. Go to the query builder. The float field will be available to be added to the query.