### PR TITLE
gh-191: Indicate to the user which fields are already in requests

### DIFF
--- a/src/app/shared/data-element-in-request/data-element-in-request.component.html
+++ b/src/app/shared/data-element-in-request/data-element-in-request.component.html
@@ -21,13 +21,13 @@ SPDX-License-Identifier: Apache-2.0
     {{ caption }}
   </button>
   <ng-container *ngIf="!suppressViewRequestsDialogButton">
-    <i
+    <span
       *ngIf="elementLinkedToRequest"
       [matTooltip]="tooltipText"
       matTooltipClass="mdm-request-icon-tooltip"
       class="fa fa-circle-check"
-    ></i>
-    <i *ngIf="!elementLinkedToRequest" class="fa fa-circle hideicon"></i>
+    ></span>
+    <span *ngIf="!elementLinkedToRequest" class="fa fa-circle hideicon"></span>
   </ng-container>
   <mat-menu #menu="matMenu">
     <ng-container *ngIf="ready">

--- a/src/app/shared/data-element-in-request/data-element-in-request.component.html
+++ b/src/app/shared/data-element-in-request/data-element-in-request.component.html
@@ -20,6 +20,15 @@ SPDX-License-Identifier: Apache-2.0
   <button #matMenuTrigger mat-raised-button color="primary" [matMenuTriggerFor]="menu">
     {{ caption }}
   </button>
+  <ng-container *ngIf="!suppressViewRequestsDialogButton">
+    <i
+      *ngIf="elementLinkedToRequest"
+      [matTooltip]="tooltipText"
+      matTooltipClass="mdm-request-icon-tooltip"
+      class="fa fa-circle-check"
+    ></i>
+    <i *ngIf="!elementLinkedToRequest" class="fa fa-circle hideicon"></i>
+  </ng-container>
   <mat-menu #menu="matMenu">
     <ng-container *ngIf="ready">
       <section>

--- a/src/app/shared/data-element-in-request/data-element-in-request.component.scss
+++ b/src/app/shared/data-element-in-request/data-element-in-request.component.scss
@@ -30,6 +30,44 @@ section {
   padding-right: 1rem;
 }
 
+.hideicon {
+  opacity: 0;
+}
+
 .mat-divider {
   margin-bottom: 0.5rem;
+}
+
+$triangle-center: 77.5%;
+$vertical-offset: 6px;
+$horizontal-offset: 8px;
+
+::ng-deep div.mat-tooltip.mdm-request-icon-tooltip {
+  color: black;
+  font-size: small;
+  font-weight: normal;
+  text-align: center;
+  background: $color-mauro-gold;
+  padding-top: 1.1em;
+  margin-top: 0.2em;
+  margin-right: 8.1em;
+  width: 165px;
+  white-space: pre-line;
+
+  clip-path: polygon(
+    // Top left point
+    0% calc(0% + $vertical-offset),
+    // center left of triangle
+    calc($triangle-center - $horizontal-offset) calc(0% + $vertical-offset),
+    // tip of triangle
+    $triangle-center 0%,
+    // center right of triangle
+    calc($triangle-center + $horizontal-offset) calc(0% + $vertical-offset),
+    // Top right point
+    100% calc(0% + $vertical-offset),
+    // Bottom right point
+    100% 100%,
+    // Bottom left point
+    0% 100%
+  );
 }

--- a/src/app/shared/data-element-in-request/data-element-in-request.component.ts
+++ b/src/app/shared/data-element-in-request/data-element-in-request.component.ts
@@ -17,8 +17,13 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
-import { DataModel, DataModelSubsetPayload } from '@maurodatamapper/mdm-resources';
-import { finalize, Observable, of, Subject, takeUntil } from 'rxjs';
+import {
+  DataModel,
+  DataModelDetail,
+  DataModelSubsetPayload,
+  Uuid,
+} from '@maurodatamapper/mdm-resources';
+import { EMPTY, finalize, Observable, of, Subject, switchMap, takeUntil } from 'rxjs';
 import { StateRouterService } from 'src/app/core/state-router.service';
 import {
   DataAccessRequestsSourceTargetIntersections,
@@ -36,6 +41,8 @@ import { ToastrService } from 'ngx-toastr';
 import { BroadcastService } from 'src/app/core/broadcast.service';
 import { DialogService } from 'src/app/data-explorer/dialog.service';
 import { RequestUpdatedData } from 'src/app/data-explorer/request-updated-dialog/request-updated-dialog.component';
+import { DataExplorerService } from 'src/app/data-explorer/data-explorer.service';
+import { TooltipHelpTextOption } from '../bookmark-toggle/bookmark-toggle.component';
 
 export interface CreateRequestEvent {
   item: DataElementSearchResult;
@@ -70,6 +77,8 @@ export class DataElementInRequestComponent implements OnInit, OnDestroy {
 
   // The list of items in the createRequest menu
   dataRequestMenuItems: DataAccessRequestMenuItem[] = [];
+  elementLinkedToRequest = false;
+  tooltipText = 'Assigned to Request';
 
   private user: UserDetails | null;
 
@@ -85,7 +94,8 @@ export class DataElementInRequestComponent implements OnInit, OnDestroy {
     private endpoints: MdmEndpointsService,
     private dialogs: DialogService,
     private toastr: ToastrService,
-    private broadcast: BroadcastService
+    private broadcast: BroadcastService,
+    private explorer: DataExplorerService
   ) {
     this.user = security.getSignedInUser();
     this.sourceTargetIntersections = {
@@ -165,6 +175,9 @@ export class DataElementInRequestComponent implements OnInit, OnDestroy {
             addedElements: event.checked ? [de] : [],
             removedElements: !event.checked ? [de] : [],
           };
+
+          this.loadIntersections();
+
           return this.dialogs
             .openRequestUpdated(requestUpdatedData)
             .afterClosed()
@@ -188,14 +201,28 @@ export class DataElementInRequestComponent implements OnInit, OnDestroy {
         .filter((sti) => sti.intersects.includes(this.dataElement!.id)) // eslint-disable-line @typescript-eslint/no-non-null-assertion
         .map((sti) => sti.targetDataModelId);
 
-    this.dataRequestMenuItems = this.sourceTargetIntersections.dataAccessRequests.map(
-      (req) => {
+    this.dataRequestMenuItems = this.sourceTargetIntersections.dataAccessRequests
+      .map((req) => {
         return {
           dataModel: req,
           containsElement: idsOfRequestsContainingElement.includes(req.id ?? ''),
         };
-      }
-    );
+      })
+      .sort();
+
+    this.elementLinkedToRequest =
+      this.dataRequestMenuItems.filter((obj) => obj.containsElement).length > 0;
+
+    const menuList = this.dataRequestMenuItems
+      .filter((obj) => obj.containsElement)
+      .map((menuItem) => {
+        return menuItem.dataModel.label;
+      })
+      .join('\n');
+
+    this.tooltipText = menuList
+      ? 'Referenced by request(s):\n' + (menuList as TooltipHelpTextOption)
+      : this.tooltipText;
   }
 
   onClickCreateRequest() {
@@ -235,6 +262,33 @@ export class DataElementInRequestComponent implements OnInit, OnDestroy {
       .on('data-intersections-refreshed')
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe((intersections) => {
+        this.sourceTargetIntersections = intersections;
+        this.refreshDataRequestMenuItems();
+      });
+  }
+
+  private loadIntersections() {
+    const dataElementIds: Uuid[] = [];
+
+    if (this.dataElement) {
+      dataElementIds.push(this.dataElement.id);
+    }
+
+    this.explorer
+      .getRootDataModel()
+      .pipe(
+        switchMap((rootModel: DataModelDetail) => {
+          if (rootModel.id) {
+            return this.dataRequests.getRequestsIntersections(
+              rootModel.id,
+              dataElementIds
+            );
+          } else {
+            return EMPTY;
+          }
+        })
+      )
+      .subscribe((intersections: DataAccessRequestsSourceTargetIntersections) => {
         this.sourceTargetIntersections = intersections;
         this.refreshDataRequestMenuItems();
       });


### PR DESCRIPTION
This pull request resolves #191 . A tick is now shown next to the data element if it has already been assigned to an unsubmitted request. If the user hovers over the tick with the mouse then they will see the list of unsubmitted requests that the field has been assigned to. When the fields are listed on the requests page, the ticks are not shown since at this point the user knows those fields are included in the request. 

When testing, use the "Add to request" button to bring up a menu that allows you to choose which requests a field is used for. The tick should disappear if no requests are selected. Likewise a tick should appear when at least one request is selected. 