### PR TITLE
gh-169 Autocomplete search/select control for query builder

### DIFF
--- a/src/app/core/app-error-handler.service.ts
+++ b/src/app/core/app-error-handler.service.ts
@@ -36,6 +36,8 @@ export class AppErrorHandlerService implements ErrorHandler {
       error = error.rejection;
     }
 
+    console.error(error);
+
     this.dialog.open(AppErrorDialogComponent, {
       data: {
         error,

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -44,6 +44,7 @@ import { MatPasswordStrengthModule } from '@angular-material-extensions/password
 import { AppErrorHandlerService } from './app-error-handler.service';
 import { AppErrorDialogComponent } from './app-error-dialog/app-error-dialog.component';
 import { OverlayContainer } from '@angular/cdk/overlay';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
 
 const angularModules = [CommonModule, FormsModule, ReactiveFormsModule, RouterModule];
 const primeNgModules = [CarouselModule];
@@ -69,6 +70,7 @@ const materialModules = [
   MatDialogModule,
   MatTooltipModule,
   MatPasswordStrengthModule,
+  MatAutocompleteModule,
 ];
 
 @NgModule({

--- a/src/app/data-explorer/data-explorer.types.ts
+++ b/src/app/data-explorer/data-explorer.types.ts
@@ -337,20 +337,24 @@ export interface DataRequestQueryPayload {
 
 export type DataRequestQuery = Required<DataRequestQueryPayload>;
 
+export type QueryOperator =
+  | '='
+  | '!='
+  | '<'
+  | '<='
+  | '>'
+  | '>='
+  | 'contains'
+  | 'like'
+  | 'startswith'
+  | 'endswith'
+  | 'in'
+  | 'not in';
+
 export interface QueryExpression {
   field: string;
-  operator:
-    | '='
-    | '!='
-    | '<'
-    | '<='
-    | '>'
-    | '>='
-    | 'contains'
-    | 'like'
-    | 'startswith'
-    | 'endswith';
-  value: string;
+  operator: QueryOperator;
+  value: any;
 }
 
 export interface QueryCondition {

--- a/src/app/data-explorer/pipes/meql.pipe.spec.ts
+++ b/src/app/data-explorer/pipes/meql.pipe.spec.ts
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 import { MeqlPipe } from './meql.pipe';
 import { TestBed } from '@angular/core/testing';
 import moment from 'moment';
-import { QueryCondition, QueryExpression } from '../data-explorer.types';
+import { QueryCondition, QueryExpression, QueryOperator } from '../data-explorer.types';
 
 const newline = '\r\n';
 const tab = '\t';
@@ -331,5 +331,72 @@ describe('MeqlPipe', () => {
       const actual = pipe.transform(query);
       expect(actual).toBe('');
     });
+  });
+
+  describe('autocomplete select options tests', () => {
+    it.each<[string, QueryOperator, string]>([
+      ['autocomplete field', 'in', 'Term 01'],
+      ['autocomplete field', 'not in', 'Term 01'],
+    ])(
+      'formats single autocomplete select option %p with operator %p correctly',
+      (field, operator, name) => {
+        const query: QueryCondition = {
+          condition: 'and',
+          rules: [
+            {
+              field,
+              operator,
+              value: [
+                {
+                  name,
+                  value: {}, // Minimum value required for tests
+                },
+              ],
+            },
+          ],
+        };
+
+        const line1 = `(${newline}`;
+        const line2 = `${tab}"${field}" ${operator} "${name}"${newline}`;
+        const line3 = ')';
+
+        const expected = `${line1}${line2}${line3}`;
+        const actual = pipe.transform(query);
+        expect(actual).toBe(expected);
+      }
+    );
+
+    it.each<[string, QueryOperator, string[]]>([
+      ['autocomplete field', 'in', ['Term 01', 'Term 02', 'Term 03']],
+      ['autocomplete field', 'not in', ['Term 01', 'Term 02', 'Term 03']],
+    ])(
+      'formats multiple autocomplete select options %p with operator %p correctly',
+      (field, operator, names) => {
+        const query: QueryCondition = {
+          condition: 'and',
+          rules: [
+            {
+              field,
+              operator,
+              value: names.map((name) => {
+                return {
+                  name,
+                  value: {}, // Minimum value required for tests
+                };
+              }),
+            },
+          ],
+        };
+
+        const combinedNames = names.join(', ');
+        const line1 = `(${newline}`;
+        const line2 = `${tab}"${field}" ${operator} "${combinedNames}"${newline}`;
+        const line3 = ')';
+
+        const expected = `${line1}${line2}${line3}`;
+        const actual = pipe.transform(query);
+        expect(actual).toBe(expected);
+      }
+    );
   });
 });

--- a/src/app/data-explorer/pipes/meql.pipe.ts
+++ b/src/app/data-explorer/pipes/meql.pipe.ts
@@ -19,6 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 import { Pipe, PipeTransform } from '@angular/core';
 import { DatePipe } from '@angular/common';
 import moment from 'moment';
+import { isAutocompleteSelectOptionArray } from 'src/app/shared/autocomplete-select/autocomplete-select.component';
 
 @Pipe({ name: 'meql', pure: false })
 export class MeqlPipe implements PipeTransform {
@@ -49,6 +50,10 @@ export class MeqlPipe implements PipeTransform {
       return `${quotes}${this._date
         .transform(value.toDate(), 'dd/MM/yyyy')
         ?.toString()}${quotes}`;
+    } else if (isAutocompleteSelectOptionArray(value)) {
+      const optionsStr =
+        value && value.length > 0 ? value.map((item) => item.name).join(', ') : 'null';
+      return `${quotes}${optionsStr}${quotes}`;
     } else {
       if (value !== undefined && value !== null) {
         return `${quotes}${value.toString()}${quotes}`;

--- a/src/app/data-explorer/querybuilder/querybuilder.component.html
+++ b/src/app/data-explorer/querybuilder/querybuilder.component.html
@@ -236,6 +236,29 @@ SPDX-License-Identifier: Apache-2.0
           </textarea>
         </mat-form-field>
       </ng-container>
+      <!-- Terminology -->
+      <ng-container
+        *queryInput="
+          let rule;
+          let options = options;
+          type: 'terminology';
+          let onChange = onChange
+        "
+      >
+        <mat-form-field
+          appearance="outline"
+          class="query-builder-input query-builder-autocomplete"
+        >
+          <mdm-autocomplete-select
+            [(ngModel)]="rule.value"
+            (ngModelChange)="onChange()"
+            placeholder="Search for terms..."
+            multiple
+            [searchResults]="termSearchResults[rule.field]"
+            (searchChange)="termSearchChanged($event, rule, options)"
+          ></mdm-autocomplete-select>
+        </mat-form-field>
+      </ng-container>
     </query-builder>
   </mat-card>
 </div>

--- a/src/app/data-explorer/querybuilder/querybuilder.component.scss
+++ b/src/app/data-explorer/querybuilder/querybuilder.component.scss
@@ -36,3 +36,8 @@ SPDX-License-Identifier: Apache-2.0
 .query-builder-number {
   width: 30%;
 }
+
+.query-builder-autocomplete {
+  width: 40%;
+  vertical-align: top;
+}

--- a/src/app/data-explorer/querybuilder/querybuilder.component.scss
+++ b/src/app/data-explorer/querybuilder/querybuilder.component.scss
@@ -34,7 +34,7 @@ SPDX-License-Identifier: Apache-2.0
 
 .query-builder-input,
 .query-builder-number {
-  width: 30%;
+  width: 40%;
 }
 
 .query-builder-autocomplete {

--- a/src/app/mauro/mdm-endpoints.service.ts
+++ b/src/app/mauro/mdm-endpoints.service.ts
@@ -36,6 +36,7 @@ import {
   MdmSessionResource,
   MdmSummaryMetadataResource,
   MdmTerminologyResource,
+  MdmTermResource,
 } from '@maurodatamapper/mdm-resources';
 import { MdmHttpClientService } from './mdm-http-client.service';
 import { MdmPluginResearchResource } from './plugins/plugin-research.resource';
@@ -64,6 +65,7 @@ export class MdmEndpointsService {
   security = new MdmSecurityResource(this.configuration, this.httpClient);
   session = new MdmSessionResource(this.configuration, this.httpClient);
   summaryMetadata = new MdmSummaryMetadataResource(this.configuration, this.httpClient);
+  term = new MdmTermResource(this.configuration, this.httpClient);
   terminology = new MdmTerminologyResource(this.configuration, this.httpClient);
 
   constructor(

--- a/src/app/mauro/mdm-http-client.service.ts
+++ b/src/app/mauro/mdm-http-client.service.ts
@@ -52,7 +52,6 @@ export class MdmHttpClientService implements MdmRestHandler {
 
     return this.http
       .request(options.method as string, url, {
-        // eslint-disable-line @typescript-eslint/no-unsafe-argument
         body: options.body,
         headers: options.headers,
         withCredentials: options.withCredentials,

--- a/src/app/mauro/terminology.service.spec.ts
+++ b/src/app/mauro/terminology.service.spec.ts
@@ -19,6 +19,10 @@ SPDX-License-Identifier: Apache-2.0
 import {
   CatalogueItemDomainType,
   TerminologyDetail,
+  FilterQueryParameters,
+  MdmIndexBody,
+  Term,
+  Uuid,
 } from '@maurodatamapper/mdm-resources';
 import { cold } from 'jest-marbles';
 import { createMdmEndpointsStub } from '../testing/stubs/mdm-endpoints.stub';
@@ -92,6 +96,64 @@ describe('TerminologyService', () => {
 
       const expected$ = cold('--a|', { a: expectedModel });
       const actual$ = service.getModel(id, CatalogueItemDomainType.CodeSet);
+      expect(actual$).toBeObservable(expected$);
+    });
+  });
+
+  describe('list terms', () => {
+    const id: Uuid = '1234';
+    const query: FilterQueryParameters = {
+      max: 20,
+      sort: 'label',
+    };
+
+    const terms: MdmIndexBody<Term> = {
+      count: 10,
+      items: [
+        {
+          id: '1',
+          domainType: CatalogueItemDomainType.Term,
+          definition: 'def 1',
+          code: 'code 1',
+        },
+        {
+          id: '2',
+          domainType: CatalogueItemDomainType.Term,
+          definition: 'def 2',
+          code: 'code 2',
+        },
+      ],
+    };
+
+    it('should return terms for a terminology', () => {
+      endpointsStub.term.list.mockImplementationOnce((mId, qry) => {
+        expect(mId).toBe(id);
+        expect(qry).toBe(query);
+        return cold('--a|', {
+          a: {
+            body: terms,
+          },
+        });
+      });
+
+      const expected$ = cold('--a|', { a: terms });
+      const actual$ = service.listTerms(id, CatalogueItemDomainType.Terminology, query);
+      expect(actual$).toBeObservable(expected$);
+    });
+
+    it('should return terms for a code set', () => {
+      endpointsStub.codeSet.terms.mockImplementationOnce((mId, qry) => {
+        expect(mId).toBe(id);
+        expect(qry).toBe(query);
+        return cold('--a|', {
+          a: {
+            body: terms,
+          },
+        });
+      });
+
+      const expected$ = cold('--a|', { a: terms });
+      const actual$ = service.listTerms(id, CatalogueItemDomainType.CodeSet, query);
       expect(actual$).toBeObservable(expected$);
     });
   });

--- a/src/app/mauro/terminology.service.ts
+++ b/src/app/mauro/terminology.service.ts
@@ -21,6 +21,10 @@ import {
   CatalogueItemDomainType,
   TerminologyDetail,
   TerminologyDetailResponse,
+  FilterQueryParameters,
+  MdmIndexBody,
+  Term,
+  TermIndexResponse,
   Uuid,
 } from '@maurodatamapper/mdm-resources';
 import { map, Observable } from 'rxjs';
@@ -51,5 +55,26 @@ export class TerminologyService {
         ? this.endpoints.codeSet.get(id)
         : this.endpoints.terminology.get(id);
     return request$.pipe(map((response: TerminologyDetailResponse) => response.body));
+  }
+
+  /**
+   * Lists the terms from a Terminology (or Code Set), with filtering options to control the result set.
+   *
+   * @param id The ID of the model to inspect.
+   * @param domainType Optional domain type of the model, either "Terminology" or "CodeSet". If not provided, "Terminology" is presumed.
+   * @param query Optional query parameters used to filter, page and sort the results.
+   * @returns A list of matching terms.
+   */
+  listTerms(
+    id: Uuid,
+    domainType?: CatalogueItemDomainType,
+    query?: FilterQueryParameters
+  ): Observable<MdmIndexBody<Term>> {
+    const request$ =
+      domainType === CatalogueItemDomainType.CodeSet
+        ? this.endpoints.codeSet.terms(id, query)
+        : this.endpoints.term.list(id, query);
+
+    return request$.pipe(map((response: TermIndexResponse) => response.body));
   }
 }

--- a/src/app/pages/my-request-detail/my-request-detail.component.ts
+++ b/src/app/pages/my-request-detail/my-request-detail.component.ts
@@ -103,6 +103,7 @@ export class MyRequestDetailComponent implements OnInit {
       sourceTargetIntersections: [],
     };
   }
+
   ngOnInit(): void {
     this.initialiseRequest();
     this.setBackButtonProperties();
@@ -112,7 +113,7 @@ export class MyRequestDetailComponent implements OnInit {
     this.route.params
       .pipe(
         switchMap((params) => {
-          const requestId = params.requestId as string;
+          const requestId: Uuid = params.requestId;
           this.state = 'loading';
           return this.dataRequests.get(requestId);
         }),
@@ -120,13 +121,13 @@ export class MyRequestDetailComponent implements OnInit {
           this.toastr.error(`Invalid Request Id. ${error}`);
           this.state = 'idle';
           return EMPTY;
-        })
+        }),
+        finalize(() => (this.state = 'idle'))
       )
       .subscribe((request) => {
         this.setRequest(request);
         this.initialiseRequestQueries();
       });
-    finalize(() => (this.state = 'idle'));
   }
 
   initialiseRequestQueries() {

--- a/src/app/pages/request-query/request-query.component.ts
+++ b/src/app/pages/request-query/request-query.component.ts
@@ -32,7 +32,7 @@ import {
   QueryCondition,
 } from 'src/app/data-explorer/data-explorer.types';
 import { DataRequestsService } from 'src/app/data-explorer/data-requests.service';
-import { QueryBuilderService } from 'src/app/mauro/query-builder.service';
+import { QueryBuilderService } from 'src/app/data-explorer/query-builder.service';
 import { IModelPage } from 'src/app/shared/types/shared.types';
 
 const defaultQueryCondition: QueryCondition = {

--- a/src/app/shared/autocomplete-select/autocomplete-select.component.html
+++ b/src/app/shared/autocomplete-select/autocomplete-select.component.html
@@ -1,0 +1,58 @@
+<!--
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+<div role="group">
+  <mat-chip-list #chipList aria-label="Selection" [disabled]="disabled">
+    <mat-chip *ngFor="let option of selected" (removed)="deselectOption(option)">
+      {{ option.name }}
+      <button matChipRemove>
+        <mat-icon>cancel</mat-icon>
+      </button>
+    </mat-chip>
+  </mat-chip-list>
+  <div class="mdm-autocomplete-select__search">
+    <input
+      #searchInput
+      type="text"
+      matInput
+      class="search-input"
+      [matAutocomplete]="auto"
+      [matChipInputFor]="chipList"
+      [formControl]="searchCtrl"
+      [placeholder]="placeholder"
+    />
+    <span *ngIf="showMatchCount">{{ searchResults.count }} found</span>
+    <button
+      *ngIf="searchCtrl.value"
+      mat-icon-button
+      aria-label="Clear"
+      (click)="clearSearch()"
+    >
+      <mat-icon>close</mat-icon>
+    </button>
+  </div>
+  <mat-autocomplete
+    #auto="matAutocomplete"
+    [displayWith]="displayWith"
+    (optionSelected)="selectOption($event)"
+  >
+    <mat-option *ngFor="let option of searchResults.options" [value]="option">
+      {{ option.name }}
+    </mat-option>
+  </mat-autocomplete>
+</div>

--- a/src/app/shared/autocomplete-select/autocomplete-select.component.scss
+++ b/src/app/shared/autocomplete-select/autocomplete-select.component.scss
@@ -16,19 +16,9 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-@import "./base/all";
-
-.query-builder {
-  .mat-form-field {
-    margin: 0 5px; /* Add a space before the next control*/
-  }
-
-  .mat-form-field-wrapper {
-    padding-bottom: 0;
-  }
-
-  /* Set the space between radio buttons */
-  .mat-radio-button {
-    padding: 10px;
+.mdm-autocomplete-select {
+  &__search {
+    display: flex;
+    align-items: baseline;
   }
 }

--- a/src/app/shared/autocomplete-select/autocomplete-select.component.spec.ts
+++ b/src/app/shared/autocomplete-select/autocomplete-select.component.spec.ts
@@ -1,0 +1,270 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import {
+  MatAutocomplete,
+  MatAutocompleteSelectedEvent,
+} from '@angular/material/autocomplete';
+import { MockComponent } from 'ng-mocks';
+import {
+  ComponentHarness,
+  setupTestModuleForComponent,
+} from 'src/app/testing/testing.helpers';
+
+import {
+  AutocompleteSelectComponent,
+  AutocompleteSelectOption,
+} from './autocomplete-select.component';
+
+describe('AutocompleteSelectComponent', () => {
+  let harness: ComponentHarness<AutocompleteSelectComponent>;
+
+  beforeEach(async () => {
+    harness = await setupTestModuleForComponent(AutocompleteSelectComponent, {
+      declarations: [MockComponent(MatAutocomplete)],
+    });
+  });
+
+  it('should create', () => {
+    expect(harness.isComponentCreated).toBeTruthy();
+  });
+
+  describe('multiple input', () => {
+    beforeEach(() => {
+      expect(harness.component.multiple).toBeFalsy();
+    });
+
+    it.each([
+      [true, true],
+      [false, false],
+      ['true', true],
+      ['false', false],
+    ])('should set the multiple input correctly from %p to %p', (value, expected) => {
+      harness.component.multiple = value;
+      expect(harness.component.multiple).toBe(expected);
+    });
+  });
+
+  describe('disabled input', () => {
+    beforeEach(() => {
+      expect(harness.component.disabled).toBeFalsy();
+    });
+
+    it.each([
+      [true, true],
+      [false, false],
+      ['true', true],
+      ['false', false],
+    ])('should set the disabled input correctly from %p to %p', (value, expected) => {
+      harness.component.disabled = value;
+      expect(harness.component.disabled).toBe(expected);
+      if (expected) {
+        expect(harness.component.searchCtrl.disabled).toBeTruthy();
+      } else {
+        expect(harness.component.searchCtrl.disabled).toBeFalsy();
+      }
+    });
+  });
+
+  describe('value input', () => {
+    beforeEach(() => {
+      expect(harness.component.value).toStrictEqual([]);
+    });
+
+    it('should match the selected property value', () => {
+      expect(harness.component.selected).toStrictEqual([]);
+
+      harness.component.value = [
+        {
+          name: 'option1',
+          value: {},
+        },
+        {
+          name: 'option2',
+          value: {},
+        },
+      ];
+
+      expect(harness.component.value).toStrictEqual(harness.component.selected);
+    });
+
+    it('should raise change events when value changes', () => {
+      // Initial value
+      harness.component.value = [
+        {
+          name: 'option1',
+          value: {},
+        },
+        {
+          name: 'option2',
+          value: {},
+        },
+      ];
+
+      // Set event spies
+      const selectedChangeSpy = jest.spyOn(harness.component.selectionChange, 'emit');
+      const stateChangesSpy = jest.spyOn(harness.component.stateChanges, 'next');
+      let onChangeCalled = false;
+      harness.component.registerOnChange(() => (onChangeCalled = true));
+
+      // Changed value
+      const newSelection = [
+        {
+          name: 'option1',
+          value: {},
+        },
+      ];
+      harness.component.value = newSelection;
+
+      expect(selectedChangeSpy).toHaveBeenCalledWith(newSelection);
+      expect(stateChangesSpy).toHaveBeenCalled();
+      expect(onChangeCalled).toBe(true);
+    });
+  });
+
+  describe('empty property', () => {
+    beforeEach(() => {
+      expect(harness.component.empty).toBeTruthy();
+    });
+
+    it('should not be empty when values are selected', () => {
+      harness.component.value = [
+        {
+          name: 'option1',
+          value: {},
+        },
+      ];
+
+      expect(harness.component.empty).toBeFalsy();
+    });
+  });
+
+  describe('showMatchCount property', () => {
+    beforeEach(() => {
+      expect(harness.component.displayMatchCount).toBeTruthy();
+      expect(harness.component.showMatchCount).toBeFalsy();
+    });
+
+    it('should not show match count when displayMatchCount is false', () => {
+      // Enter a value but force display off
+      harness.component.displayMatchCount = false;
+      harness.component.searchCtrl.setValue('test');
+
+      expect(harness.component.showMatchCount).toBeFalsy();
+    });
+
+    it('should not show match count when no text entered', () => {
+      harness.component.displayMatchCount = true;
+      harness.component.searchCtrl.setValue('');
+
+      expect(harness.component.showMatchCount).toBeFalsy();
+    });
+
+    it('should show match count when text entered', () => {
+      harness.component.displayMatchCount = true;
+      harness.component.searchCtrl.setValue('test');
+
+      expect(harness.component.showMatchCount).toBeTruthy();
+    });
+  });
+
+  describe('clearSearch', () => {
+    it('should clear current text', () => {
+      harness.component.searchCtrl.setValue('test');
+      harness.component.clearSearch();
+      expect(harness.component.searchCtrl.value).toBe('');
+    });
+  });
+
+  describe('selectOption', () => {
+    const option: AutocompleteSelectOption = {
+      name: 'test',
+      value: {},
+    };
+
+    const event = {
+      option: {
+        value: option,
+      },
+    } as MatAutocompleteSelectedEvent;
+
+    it('should do nothing when disabled', () => {
+      const selectionChangeSpy = jest.spyOn(harness.component.selectionChange, 'emit');
+
+      harness.component.disabled = true;
+      harness.component.selectOption(event);
+
+      expect(selectionChangeSpy).not.toHaveBeenCalled();
+    });
+
+    it('should add option to selected list', () => {
+      const initialSelection = [
+        {
+          name: 'first',
+          value: {},
+        },
+      ];
+
+      // Initial state
+      harness.component.searchCtrl.setValue('test');
+      harness.component.value = initialSelection;
+
+      const selectionChangeSpy = jest.spyOn(harness.component.selectionChange, 'emit');
+
+      harness.component.selectOption(event);
+
+      expect(selectionChangeSpy).toHaveBeenCalledWith(initialSelection.concat(option));
+      expect(harness.component.searchCtrl.value).toBe('');
+    });
+  });
+
+  describe('deselectOption', () => {
+    const option: AutocompleteSelectOption = {
+      name: 'test',
+      value: {},
+    };
+
+    it('should do nothing when disabled', () => {
+      const selectionChangeSpy = jest.spyOn(harness.component.selectionChange, 'emit');
+
+      harness.component.disabled = true;
+      harness.component.deselectOption(option);
+
+      expect(selectionChangeSpy).not.toHaveBeenCalled();
+    });
+
+    it('should remove option from selected list', () => {
+      const initialSelection = [
+        {
+          name: 'first',
+          value: {},
+        },
+        option,
+      ];
+
+      // Initial state
+      harness.component.value = initialSelection;
+
+      const selectionChangeSpy = jest.spyOn(harness.component.selectionChange, 'emit');
+
+      harness.component.deselectOption(option);
+
+      expect(selectionChangeSpy).toHaveBeenCalledWith(initialSelection.splice(0, 1));
+    });
+  });
+});

--- a/src/app/shared/autocomplete-select/autocomplete-select.component.ts
+++ b/src/app/shared/autocomplete-select/autocomplete-select.component.ts
@@ -1,0 +1,496 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { FocusMonitor } from '@angular/cdk/a11y';
+import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
+import { SelectionModel } from '@angular/cdk/collections';
+import {
+  Component,
+  DoCheck,
+  ElementRef,
+  EventEmitter,
+  HostBinding,
+  Input,
+  OnDestroy,
+  OnInit,
+  Optional,
+  Output,
+  Self,
+  ViewChild,
+} from '@angular/core';
+import {
+  ControlValueAccessor,
+  FormControl,
+  FormGroupDirective,
+  NgControl,
+  NgForm,
+  Validators,
+} from '@angular/forms';
+import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
+import { ErrorStateMatcher, mixinErrorState } from '@angular/material/core';
+import { MatFormFieldControl } from '@angular/material/form-field';
+import {
+  debounceTime,
+  delay,
+  distinctUntilChanged,
+  filter,
+  startWith,
+  Subject,
+  tap,
+  takeUntil,
+} from 'rxjs';
+
+/* eslint-disable @typescript-eslint/member-ordering */
+
+/**
+ * Represents a single option to interact with in the {@link AutocompleteSelectComponent}.
+ */
+export interface AutocompleteSelectOption {
+  /**
+   * The display name of this option to view in the control.
+   */
+  name: string;
+
+  /**
+   * The value that the option represents.
+   */
+  value: any;
+}
+
+/**
+ * Represents a set of {@link AutocompleteSelectOption} values.
+ */
+export interface AutocompleteSelectOptionSet {
+  /**
+   * The total count of options found.
+   *
+   * This does not have to be the same as the length of the {@link options} array. This could
+   * represent the total number of search results found in a query, with only the top set of results
+   * actually returned.
+   */
+  count: number;
+
+  /**
+   * The collection of options to display.
+   */
+  options: AutocompleteSelectOption[];
+}
+
+export const isAutocompleteSelectOption = (
+  value: any
+): value is AutocompleteSelectOption => {
+  const hasName = value?.name;
+  const hasValue = value?.value;
+  return hasName || hasValue;
+};
+
+export const isAutocompleteSelectOptionArray = (
+  value: any
+): value is AutocompleteSelectOption[] => {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+
+  const array = value as any[];
+  return array.every((item) => isAutocompleteSelectOption(item));
+};
+
+/**
+ * Base mixin class for the {@link AutocompleteSelectComponent}.
+ *
+ * Created as part of the setup for the component to use the {@link MatFormFieldControl} type.
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const _AutocompleteSelectComponentMixinBase = mixinErrorState(
+  class {
+    /**
+     * Emits whenever the component state changes and should cause the parent
+     * form-field to update. Implemented as part of `MatFormFieldControl`.
+     */
+    readonly stateChanges = new Subject<void>();
+
+    constructor(
+      public _elementRef: ElementRef,
+      public _defaultErrorStateMatcher: ErrorStateMatcher,
+      public _parentForm: NgForm,
+      public _parentFormGroup: FormGroupDirective,
+      /**
+       * Form control bound to the component.
+       * Implemented as part of `MatFormFieldControl`.
+       */
+      public ngControl: NgControl
+    ) {}
+  }
+);
+
+/**
+ * Component to perform an autocomplete search and select options from the results.
+ *
+ * Supports single and multi-select via the {@link AutocompleteSelectComponent.multiple} input.
+ *
+ * This component supports integration with Angular Forms and the Angular Material `mat-form-field` component.
+ *
+ * To have interactive options be presented to the autocomplete list while typing, you need to set the
+ * {@link AutocompleteSelectComponent.searchResults} input binding, then attach to the
+ * {@link AutocompleteSelectComponent.searchChange} output binding. The output will respond to changes in the search text
+ * entered, this will then allow the parent component to decide what options to present based in this change and set back
+ * to the {@link AutocompleteSelectComponent.searchResults} input to rerender the autocomplete list.
+ *
+ * An example of a parent component:
+ *
+ * Template:
+ *
+ * ```html
+ * <div>
+ *   <mdm-autocomplete-search [searchResults]="myResults" (searchChange)="searchChanged($event)">
+ *   </mdm-autocomplete-search>
+ * </div>
+ * ```
+ *
+ * Code:
+ *
+ * ```ts
+ * class MyComponent {
+ *   // Bind to the component input with initial value
+ *   myResults: AutocompleteSelectOptionSet = { count: 0, options: [] };
+ *
+ *   searchChanged(value: string | undefined) {
+ *     // New text entered, perform some kind of search to get new results
+ *     fetchFromServer(value).pipe(
+ *       map(response => {
+ *        return {
+ *          count: response.body.count,
+ *          options: response.body.items.map((item) => {
+ *            return {
+ *              name: item.label,
+ *              value: item,
+ *            };
+ *          }),
+ *        };
+ *       })
+ *     )
+ *     .subscribe(results => this.myResults = results)
+ *   }
+ * }
+ * ```
+ */
+@Component({
+  selector: 'mdm-autocomplete-select',
+  templateUrl: './autocomplete-select.component.html',
+  styleUrls: ['./autocomplete-select.component.scss'],
+  providers: [
+    {
+      provide: MatFormFieldControl,
+      useExisting: AutocompleteSelectComponent,
+    },
+  ],
+})
+export class AutocompleteSelectComponent
+  extends _AutocompleteSelectComponentMixinBase
+  implements
+    OnInit,
+    OnDestroy,
+    DoCheck,
+    ControlValueAccessor,
+    MatFormFieldControl<AutocompleteSelectOption[]>
+{
+  private static nextUniqueId = 0;
+
+  @HostBinding()
+  id = `mdm-autocomplete-select-${AutocompleteSelectComponent.nextUniqueId++}`;
+
+  @ViewChild('searchInput') searchInput?: ElementRef<HTMLInputElement>;
+
+  /**
+   * Display the search results in the autocomplete dropdown.
+   *
+   * Provide a list of options and a total count to represent the total number of matches found.
+   */
+  @Input() searchResults: AutocompleteSelectOptionSet = { count: 0, options: [] };
+
+  /**
+   * State if the number of matches found should be displayed in the component.
+   */
+  @Input() displayMatchCount = true;
+
+  /**
+   * State if the component should allow multiple selections.
+   */
+  @Input() get multiple(): boolean {
+    return this._multiple;
+  }
+
+  set multiple(value: BooleanInput) {
+    this._multiple = coerceBooleanProperty(value);
+  }
+
+  @Input() get value(): AutocompleteSelectOption[] | null {
+    return this._selectionModel.selected;
+  }
+
+  set value(newValue: AutocompleteSelectOption[] | null) {
+    this.assignValue(newValue);
+  }
+
+  @Input()
+  get placeholder(): string {
+    return this._placeholder;
+  }
+
+  set placeholder(value: string) {
+    this._placeholder = value;
+    this.stateChanges.next();
+  }
+
+  @Input()
+  get required(): boolean {
+    return (
+      this._required ??
+      this.ngControl?.control?.hasValidator(Validators.required) ?? // eslint-disable-line @typescript-eslint/unbound-method
+      false
+    );
+  }
+
+  set required(value: BooleanInput) {
+    this._required = coerceBooleanProperty(value);
+    this.stateChanges.next();
+  }
+
+  @Input() get disabled(): boolean {
+    return this._disabled;
+  }
+
+  set disabled(value: BooleanInput) {
+    this._disabled = coerceBooleanProperty(value);
+    if (this._disabled) {
+      this.searchCtrl.disable();
+    } else {
+      this.searchCtrl.enable();
+    }
+  }
+
+  // eslint-disable-next-line @angular-eslint/no-input-rename
+  @Input('aria-describedby') userAriaDescribedBy?: string | undefined;
+
+  /**
+   * Output event raised when the selection(s) have changed.
+   *
+   * Attach to this event handler if not using the component in an Angular Form.
+   */
+  @Output() selectionChange = new EventEmitter<AutocompleteSelectOption[]>();
+
+  /**
+   * Output event raised when a new search value has been entered in the autocomplete text input field.
+   *
+   * When raised, set the {@link AutocompleteSelectComponent.searchResults} input binding with a new value to
+   * render the new changes.
+   */
+  @Output() searchChange = new EventEmitter<string | undefined>();
+
+  searchCtrl = new FormControl();
+  focused = false;
+  controlType?: string | undefined = 'mdm-autocomplete-select';
+
+  private _multiple = false;
+  private _touched = false;
+  private _disabled = false;
+  private _placeholder = '';
+  private _required: boolean | undefined;
+  private _selectionModel = new SelectionModel<AutocompleteSelectOption>(true);
+  private _unsubscribe$ = new Subject<void>();
+
+  /** Part of the ControlValueAccessor interface */
+  private _onChange: (values: AutocompleteSelectOption[]) => void = (_) => {};
+
+  /** Part of the ControlValueAccessor interface */
+  private _onTouched = () => {};
+
+  /**
+   * Gets the current list of selected options.
+   */
+  get selected(): AutocompleteSelectOption[] {
+    return this._selectionModel.selected;
+  }
+
+  get empty(): boolean {
+    return this._selectionModel.isEmpty();
+  }
+
+  get showMatchCount() {
+    return (
+      this.displayMatchCount && this.searchCtrl.value && this.searchCtrl.value.length > 0
+    );
+  }
+
+  get shouldLabelFloat() {
+    return (
+      this.focused ||
+      !this.empty ||
+      (this.searchCtrl.value && this.searchCtrl.value.length > 0)
+    );
+  }
+
+  constructor(
+    elementRef: ElementRef,
+    defaultErrorStateMatcher: ErrorStateMatcher,
+    @Optional() parentForm: NgForm,
+    @Optional() parentFormGroup: FormGroupDirective,
+    @Optional() @Self() ngControl: NgControl,
+    private _focusMonitor: FocusMonitor
+  ) {
+    super(elementRef, defaultErrorStateMatcher, parentForm, parentFormGroup, ngControl);
+
+    if (this.ngControl) {
+      // Note: we provide the value accessor through here, instead of
+      // the `providers` to avoid running into a circular import.
+      this.ngControl.valueAccessor = this;
+    }
+
+    this._focusMonitor
+      .monitor(this._elementRef.nativeElement as HTMLElement, true)
+      .pipe(
+        // Use delay to prevent ExpressionChangedAfterItHasBeenCheckedError
+        delay(0),
+        tap((focusOrigin) => {
+          this.focused = !!focusOrigin;
+          this.stateChanges.next();
+        })
+      )
+      .subscribe();
+
+    this.searchCtrl.valueChanges
+      .pipe(
+        takeUntil(this._unsubscribe$),
+        startWith(''),
+        debounceTime(400),
+        distinctUntilChanged(),
+        filter((val) => typeof val === 'string')
+      )
+      .subscribe((value: string | undefined) => {
+        this.searchChange.emit(value);
+      });
+  }
+
+  ngOnInit(): void {
+    this._selectionModel = new SelectionModel<AutocompleteSelectOption>(this.multiple);
+    this.stateChanges.next();
+  }
+
+  ngOnDestroy(): void {
+    this.stateChanges.complete();
+    this._focusMonitor.stopMonitoring(this._elementRef.nativeElement as HTMLElement);
+    this._unsubscribe$.next();
+    this._unsubscribe$.complete();
+  }
+
+  ngDoCheck(): void {
+    this.updateErrorState();
+  }
+
+  clearSearch() {
+    this.searchCtrl.setValue('');
+    if (this.searchInput) {
+      this.searchInput.nativeElement.value = '';
+    }
+  }
+
+  selectOption(event: MatAutocompleteSelectedEvent) {
+    if (this.disabled) {
+      return;
+    }
+
+    const option = event.option.value as AutocompleteSelectOption;
+    this._selectionModel.select(option);
+    this.clearSearch();
+    this.propagateChanges();
+    this.markAsTouched();
+  }
+
+  deselectOption(option: AutocompleteSelectOption) {
+    if (this.disabled) {
+      return;
+    }
+
+    this._selectionModel.deselect(option);
+    this.propagateChanges();
+    this.markAsTouched();
+  }
+
+  /**
+   * Function callback to use with `mat-autocomplete` to render the correct string.
+   *
+   * Note: use of function asignment "=" is intentional to use correct "this" binding.
+   */
+  displayWith = (val: AutocompleteSelectOption): string => {
+    return val?.name;
+  };
+
+  focus() {
+    if (!this.focused) {
+      this._elementRef.nativeElement.focus();
+    }
+  }
+
+  setDescribedByIds(ids: string[]): void {
+    this.userAriaDescribedBy = ids.join(' ');
+  }
+
+  onContainerClick(): void {
+    this.focus();
+  }
+
+  writeValue(value: AutocompleteSelectOption[] | null): void {
+    this.assignValue(value);
+  }
+
+  registerOnChange(fn: any): void {
+    this._onChange = fn;
+  }
+
+  registerOnTouched(fn: any): void {
+    this._onTouched = fn;
+  }
+
+  setDisabledState?(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+  }
+
+  private assignValue(newValue: AutocompleteSelectOption[] | null): boolean {
+    if (!newValue) {
+      return false;
+    }
+
+    this._selectionModel.clear();
+    newValue.forEach((val) => this._selectionModel.select(val));
+    this.propagateChanges();
+    return true;
+  }
+
+  private propagateChanges() {
+    this._onChange(this.selected);
+    this.selectionChange.emit(this.selected);
+    this.stateChanges.next();
+  }
+
+  private markAsTouched() {
+    if (!this._touched) {
+      this._onTouched();
+      this._touched = true;
+    }
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -34,6 +34,7 @@ import { CallToActionComponent } from './call-to-action/call-to-action.component
 import { DataElementInRequestComponent } from './data-element-in-request/data-element-in-request.component';
 import { DataElementMultiSelectComponent } from './data-element-multi-select/data-element-multi-select.component';
 import { ConfirmationDialogComponent } from './confirmation-dialog/confirmation-dialog.component';
+import { AutocompleteSelectComponent } from './autocomplete-select/autocomplete-select.component';
 
 @NgModule({
   declarations: [
@@ -52,6 +53,7 @@ import { ConfirmationDialogComponent } from './confirmation-dialog/confirmation-
     DataElementInRequestComponent,
     DataElementMultiSelectComponent,
     ConfirmationDialogComponent,
+    AutocompleteSelectComponent,
   ],
   imports: [CoreModule, NgChartsModule],
   exports: [
@@ -68,6 +70,7 @@ import { ConfirmationDialogComponent } from './confirmation-dialog/confirmation-
     CallToActionComponent,
     DataElementInRequestComponent,
     DataElementMultiSelectComponent,
+    AutocompleteSelectComponent,
   ],
 })
 export class SharedModule {}

--- a/src/app/testing/stubs/mdm-endpoints.stub.ts
+++ b/src/app/testing/stubs/mdm-endpoints.stub.ts
@@ -60,6 +60,7 @@ import {
   createProfileStub,
   MdmProfileResourcesStub,
 } from './mdm-resources/profile-resource.stub';
+import { createTermStub, MdmTermResourceStub } from './mdm-resources/term-resource.stub';
 import {
   createCodeSetStub,
   MdmCodeSetResourceStub,
@@ -83,6 +84,7 @@ export interface MdmEndpointsServiceStub {
   session: MdmSessionResourceStub;
   profile: MdmProfileResourcesStub;
   terminology: MdmTerminologyResourceStub;
+  term: MdmTermResourceStub;
 }
 
 export const createMdmEndpointsStub = (): MdmEndpointsServiceStub => {
@@ -100,5 +102,6 @@ export const createMdmEndpointsStub = (): MdmEndpointsServiceStub => {
     session: createSessionStub(),
     profile: createProfileStub(),
     terminology: createTerminologyStub(),
+    term: createTermStub(),
   };
 };

--- a/src/app/testing/stubs/mdm-resources/code-set-resource.stub.ts
+++ b/src/app/testing/stubs/mdm-resources/code-set-resource.stub.ts
@@ -16,15 +16,24 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { CodeSetDetailResponse, Uuid } from '@maurodatamapper/mdm-resources';
+import {
+  CodeSetDetailResponse,
+  FilterQueryParameters,
+  TermIndexResponse,
+  Uuid,
+} from '@maurodatamapper/mdm-resources';
 import { Observable } from 'rxjs';
 
 export interface MdmCodeSetResourceStub {
   get: jest.MockedFunction<(id: Uuid) => Observable<CodeSetDetailResponse>>;
+  terms: jest.MockedFunction<
+    (id: Uuid, query?: FilterQueryParameters) => Observable<TermIndexResponse>
+  >;
 }
 
 export const createCodeSetStub = (): MdmCodeSetResourceStub => {
   return {
     get: jest.fn(),
+    terms: jest.fn(),
   };
 };

--- a/src/app/testing/stubs/mdm-resources/term-resource.stub.ts
+++ b/src/app/testing/stubs/mdm-resources/term-resource.stub.ts
@@ -16,19 +16,21 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-@import "./base/all";
+import {
+  FilterQueryParameters,
+  TermIndexResponse,
+  Uuid,
+} from '@maurodatamapper/mdm-resources';
+import { Observable } from 'rxjs';
 
-.query-builder {
-  .mat-form-field {
-    margin: 0 5px; /* Add a space before the next control*/
-  }
-
-  .mat-form-field-wrapper {
-    padding-bottom: 0;
-  }
-
-  /* Set the space between radio buttons */
-  .mat-radio-button {
-    padding: 10px;
-  }
+export interface MdmTermResourceStub {
+  list: jest.MockedFunction<
+    (id: Uuid, query?: FilterQueryParameters) => Observable<TermIndexResponse>
+  >;
 }
+
+export const createTermStub = (): MdmTermResourceStub => {
+  return {
+    list: jest.fn(),
+  };
+};


### PR DESCRIPTION
Resolves #169

Custom form control for using autocomplete search and multi-select to pick options for a cohort query. Ideally to be used for scenarios where a large number of option values are present for a field e.g. mapped to a Terminology.

- Combine mat-autocomplete and mat-chip-list components into one
- Implement interfaces required for integration with Angular Forms (ControlValueAccessor) and Angular Material (MatFormFieldControl)
- Integrate into QueryBuilderComponent when data element uses a data type mapped to a Terminology or Code Set
- Render MEQL correctly for autocomplete selected options
- Move QueryBuilderService to DataExplorerModule
- Update QueryBuilderService tests to support new terminology field type
- Add further tests for MeqlPipe
- Add tests to AutocompleteSelectComponent (not exhaustive)
- eslint fixes, including other code to remove warnings
  - QueryBuilderComponent
  - HttpClientService
  - QueryBuilderService
  - MyRequestDetailComponent
  - RequestQueryComponent

# Screenshots

![image](https://user-images.githubusercontent.com/3219480/212121170-222779b1-5fe0-4140-9544-31255a240438.png)

# Testing

To test this feature, you need to make modifications to your mdm-explorer data model via `mdm-ui`:

1. Go to the "modules" data model and view the "Types" tab.
2. Click "Add Data Type", then "Create a New Data Type".
3. Under "Data Type Details", select "Type" as "Terminology" or "Code Set", select a model with many terms, then set any other values as you wish. Click "Submit Data Type".
4. Now select one of the data model classes e.g. "modules > Demographics > Ethnicity (ARIA)", then view the "Elements" tab.
5. Click "Add Data Element", then "Create a New Data Element".
6. Fill in the details and select the data type you created above. Click "Submit Data Element".

Once that is done, go back to `mdm-explorer`:

1. Search for the new data element you created above.
2. Add this data element to a data request (new or existing).
3. Open the request, then edit the cohort/data query.
4. In the query builder, you should now see the option for your data element to be used as a "terminology" type, with autocomplete and select control. Start typing values to search for terms, then add to your query.