### PR TITLE
gh-200 Update Data Element page appearance

### DIFF
--- a/src/app/mauro/mdm-endpoints.service.ts
+++ b/src/app/mauro/mdm-endpoints.service.ts
@@ -21,6 +21,7 @@ import {
   MdmApiPropertyResources,
   MdmCatalogueItemResource,
   MdmCatalogueUserResource,
+  MdmCodeSetResource,
   MdmDataClassResource,
   MdmDataElementResource,
   MdmDataFlowResource,
@@ -34,6 +35,7 @@ import {
   MdmSecurityResource,
   MdmSessionResource,
   MdmSummaryMetadataResource,
+  MdmTerminologyResource,
 } from '@maurodatamapper/mdm-resources';
 import { MdmHttpClientService } from './mdm-http-client.service';
 import { MdmPluginResearchResource } from './plugins/plugin-research.resource';
@@ -45,6 +47,7 @@ export class MdmEndpointsService {
   apiProperties = new MdmApiPropertyResources(this.configuration, this.httpClient);
   catalogueItem = new MdmCatalogueItemResource(this.configuration, this.httpClient);
   catalogueUser = new MdmCatalogueUserResource(this.configuration, this.httpClient);
+  codeSet = new MdmCodeSetResource(this.configuration, this.httpClient);
   dataClass = new MdmDataClassResource(this.configuration, this.httpClient);
   dataElement = new MdmDataElementResource(this.configuration, this.httpClient);
   dataFlow = new MdmDataFlowResource(this.configuration, this.httpClient);
@@ -61,6 +64,7 @@ export class MdmEndpointsService {
   security = new MdmSecurityResource(this.configuration, this.httpClient);
   session = new MdmSessionResource(this.configuration, this.httpClient);
   summaryMetadata = new MdmSummaryMetadataResource(this.configuration, this.httpClient);
+  terminology = new MdmTerminologyResource(this.configuration, this.httpClient);
 
   constructor(
     private configuration: MdmResourcesConfiguration,

--- a/src/app/mauro/terminology.service.spec.ts
+++ b/src/app/mauro/terminology.service.spec.ts
@@ -1,0 +1,98 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import {
+  CatalogueItemDomainType,
+  TerminologyDetail,
+} from '@maurodatamapper/mdm-resources';
+import { cold } from 'jest-marbles';
+import { createMdmEndpointsStub } from '../testing/stubs/mdm-endpoints.stub';
+import { setupTestModuleForService } from '../testing/testing.helpers';
+import { MdmEndpointsService } from './mdm-endpoints.service';
+
+import { TerminologyService } from './terminology.service';
+
+describe('TerminologyService', () => {
+  let service: TerminologyService;
+  const endpointsStub = createMdmEndpointsStub();
+
+  beforeEach(() => {
+    service = setupTestModuleForService(TerminologyService, {
+      providers: [
+        {
+          provide: MdmEndpointsService,
+          useValue: endpointsStub,
+        },
+      ],
+    });
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('get model', () => {
+    const id = '123';
+
+    it('should get a terminology', () => {
+      const expectedModel: TerminologyDetail = {
+        id,
+        label: 'test model',
+        domainType: CatalogueItemDomainType.Terminology,
+        availableActions: ['show'],
+        finalised: true,
+      };
+
+      endpointsStub.terminology.get.mockImplementationOnce((mId) => {
+        expect(mId).toBe(id);
+        return cold('--a|', {
+          a: {
+            body: expectedModel,
+          },
+        });
+      });
+
+      const expected$ = cold('--a|', { a: expectedModel });
+      const actual$ = service.getModel(id, CatalogueItemDomainType.Terminology);
+      expect(actual$).toBeObservable(expected$);
+    });
+
+    it('should get a codeset', () => {
+      const expectedModel: TerminologyDetail = {
+        id,
+        label: 'test model',
+        domainType: CatalogueItemDomainType.CodeSet,
+        availableActions: ['show'],
+        finalised: true,
+      };
+
+      endpointsStub.codeSet.get.mockImplementationOnce((mId) => {
+        expect(mId).toBe(id);
+        return cold('--a|', {
+          a: {
+            body: expectedModel,
+          },
+        });
+      });
+
+      const expected$ = cold('--a|', { a: expectedModel });
+      const actual$ = service.getModel(id, CatalogueItemDomainType.CodeSet);
+      expect(actual$).toBeObservable(expected$);
+    });
+  });
+});

--- a/src/app/mauro/terminology.service.ts
+++ b/src/app/mauro/terminology.service.ts
@@ -1,0 +1,55 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Injectable } from '@angular/core';
+import {
+  CatalogueItemDomainType,
+  TerminologyDetail,
+  TerminologyDetailResponse,
+  Uuid,
+} from '@maurodatamapper/mdm-resources';
+import { map, Observable } from 'rxjs';
+import { MdmEndpointsService } from './mdm-endpoints.service';
+
+/**
+ * Service to handle data interactions with Terminologies and related items, such as Terms and Code Sets.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class TerminologyService {
+  constructor(private endpoints: MdmEndpointsService) {}
+
+  /**
+   * Gets a Terminology or Code Set.
+   *
+   * @param id The ID of the model to get.
+   * @param domainType Optional domain type of the model, either "Terminology" or "CodeSet". If not provided, "Terminology" is presumed.
+   * @returns The matching model
+   */
+  getModel(
+    id: Uuid,
+    domainType?: CatalogueItemDomainType
+  ): Observable<TerminologyDetail> {
+    const request$ =
+      domainType === CatalogueItemDomainType.CodeSet
+        ? this.endpoints.codeSet.get(id)
+        : this.endpoints.terminology.get(id);
+    return request$.pipe(map((response: TerminologyDetailResponse) => response.body));
+  }
+}

--- a/src/app/pages/data-element/data-element.component.html
+++ b/src/app/pages/data-element/data-element.component.html
@@ -26,7 +26,7 @@ SPDX-License-Identifier: Apache-2.0
   <div *ngIf="dataElement" class="highlight-box mdm-data-element-detail">
     <div class="mdm-data-element-detail__header">
       <span>
-        <h3>{{ dataElement?.label }}</h3>
+        <h3>{{ dataElement.label }}</h3>
       </span>
       <span>
         <mdm-data-element-in-request
@@ -54,29 +54,24 @@ SPDX-License-Identifier: Apache-2.0
         *ngIf="dataElement.classifiers && dataElement.classifiers.length > 0"
         class="mdm-data-element-card"
       >
-        <mdm-classifiers [classifiers]="dataElement?.classifiers"></mdm-classifiers>
+        <mdm-classifiers [classifiers]="dataElement.classifiers"></mdm-classifiers>
       </mat-card>
 
-      <mat-card class="mdm-data-element-card">
-        <h2>Data Element</h2>
+      <mat-card
+        *ngIf="dataElement.description && dataElement.description.length > 0"
+        class="mdm-data-element-card"
+      >
         <p>
-          <span class="mdm-data-element-property-name">Label: </span
-          >{{ dataElement?.label }}
-        </p>
-        <p>
-          <span class="mdm-data-element-property-name">Description: </span
-          >{{ dataElement?.description }}
+          {{ dataElement.description }}
         </p>
       </mat-card>
 
       <mat-card class="mdm-data-element-card">
         <h2>Data Type</h2>
         <p>
-          <span class="mdm-data-element-property-name">Label: </span
-          >{{ dataElement.dataType?.label }}
+          {{ dataElement.dataType?.label }}
         </p>
         <div *ngIf="dataElement.dataType?.domainType == 'EnumerationType'">
-          <h3>List of enumeration values</h3>
           <table class="table table-striped" aria-label="Enumeration values">
             <thead>
               <tr>
@@ -94,9 +89,24 @@ SPDX-License-Identifier: Apache-2.0
             </tbody>
           </table>
         </div>
+        <div
+          *ngIf="dataElement.dataType?.domainType === 'ModelDataType' && dataTypeModel"
+        >
+          <p>
+            <span class="mdm-data-element-property-name">Model: </span
+            >{{ dataTypeModel.label }}
+          </p>
+          <p>
+            <span class="mdm-data-element-property-name">Type: </span
+            >{{ dataTypeModel.domainType }}
+          </p>
+        </div>
       </mat-card>
 
-      <mat-card *ngIf="researchProfile" class="mdm-data-element-card">
+      <mat-card
+        *ngIf="researchProfile && researchProfile.sections.length > 0"
+        class="mdm-data-element-card"
+      >
         <mdm-data-element-profile [profile]="researchProfile"></mdm-data-element-profile>
       </mat-card>
 

--- a/src/app/pages/data-element/data-element.component.spec.ts
+++ b/src/app/pages/data-element/data-element.component.spec.ts
@@ -54,6 +54,8 @@ import { DataElementProfileComponent } from './data-element-profile/data-element
 import { MatIcon } from '@angular/material/icon';
 import { MatCard } from '@angular/material/card';
 import { MatTooltip } from '@angular/material/tooltip';
+import { createTerminologyServiceStub } from 'src/app/testing/stubs/terminology.stub';
+import { TerminologyService } from 'src/app/mauro/terminology.service';
 
 describe('DataElementComponent', () => {
   let harness: ComponentHarness<DataElementComponent>;
@@ -62,6 +64,7 @@ describe('DataElementComponent', () => {
   const toastrStub = createToastrServiceStub();
   const dataRequestsStub = createDataRequestsServiceStub();
   const profileStub = createProfileServiceStub();
+  const terminologiesStub = createTerminologyServiceStub();
   const config: DataExplorerConfiguration = {
     rootDataModelPath: 'my test model',
     profileServiceName: 'Profile Service',
@@ -110,6 +113,10 @@ describe('DataElementComponent', () => {
         {
           provide: ToastrService,
           useValue: toastrStub,
+        },
+        {
+          provide: TerminologyService,
+          useValue: terminologiesStub,
         },
         {
           provide: DATA_EXPLORER_CONFIGURATION,
@@ -237,19 +244,6 @@ describe('DataElementComponent', () => {
     // any further details of the profile display should be tested within the data-element-profile.component tests
   });
 
-  it('should display data element description', () => {
-    const component = harness.component;
-    const dom = harness.fixture.nativeElement;
-    harness.detectChanges();
-    const descriptionContainer = (dom.querySelectorAll('h2') as HTMLElement[])[0]
-      .nextSibling?.nextSibling as HTMLElement;
-    const descriptionHtml = descriptionContainer.innerHTML;
-    const descriptionMatcher = new RegExp(
-      `.*Description.*${component.dataElement?.description}.*`
-    );
-    expect(descriptionHtml).toMatch(descriptionMatcher);
-  });
-
   it('should display breadcrumbs', () => {
     const component = harness.component;
     const dom = harness.fixture.nativeElement;
@@ -265,17 +259,6 @@ describe('DataElementComponent', () => {
     );
     /* eslint-enable @typescript-eslint/no-non-null-assertion */
     expect(breadcrumbContainer.innerHTML).toMatch(breadcrumbMatcher);
-  });
-
-  it('should display data element label', () => {
-    const component = harness.component;
-    const dom = harness.fixture.nativeElement;
-    harness.detectChanges();
-    const labelContainer = (dom.querySelectorAll('h2') as HTMLElement[])[0]
-      .nextSibling as HTMLElement;
-    const labelHtml = labelContainer.innerHTML;
-    const labelMatcher = new RegExp(`.*Label.*${component.dataElement?.label}.*`);
-    expect(labelHtml).toMatch(labelMatcher);
   });
 
   describe('toggleBookmark', () => {

--- a/src/app/testing/stubs/mdm-endpoints.stub.ts
+++ b/src/app/testing/stubs/mdm-endpoints.stub.ts
@@ -60,11 +60,20 @@ import {
   createProfileStub,
   MdmProfileResourcesStub,
 } from './mdm-resources/profile-resource.stub';
+import {
+  createCodeSetStub,
+  MdmCodeSetResourceStub,
+} from './mdm-resources/code-set-resource.stub';
+import {
+  createTerminologyStub,
+  MdmTerminologyResourceStub,
+} from './mdm-resources/terminology-resource.stub';
 
 export interface MdmEndpointsServiceStub {
   apiProperties: MdmApiPropertiesResourceStub;
   catalogueItem: MdmCatalogueItemResourceStub;
   catalogueUser: MdmCatalogueUserResourceStub;
+  codeSet: MdmCodeSetResourceStub;
   dataClass: MdmDataClassResourceStub;
   dataElement: MdmDataElementResourceStub;
   dataModel: MdmDataModelResourcesStub;
@@ -73,6 +82,7 @@ export interface MdmEndpointsServiceStub {
   security: MdmSecurityResourceStub;
   session: MdmSessionResourceStub;
   profile: MdmProfileResourcesStub;
+  terminology: MdmTerminologyResourceStub;
 }
 
 export const createMdmEndpointsStub = (): MdmEndpointsServiceStub => {
@@ -80,6 +90,7 @@ export const createMdmEndpointsStub = (): MdmEndpointsServiceStub => {
     apiProperties: createApiPropertiesStub(),
     catalogueItem: createCatalogueItemStub(),
     catalogueUser: createCatalogueUserStub(),
+    codeSet: createCodeSetStub(),
     dataClass: createDataClassStub(),
     dataElement: createDataElementStub(),
     dataModel: createDataModelStub(),
@@ -88,5 +99,6 @@ export const createMdmEndpointsStub = (): MdmEndpointsServiceStub => {
     security: createSecurityStub(),
     session: createSessionStub(),
     profile: createProfileStub(),
+    terminology: createTerminologyStub(),
   };
 };

--- a/src/app/testing/stubs/mdm-resources/code-set-resource.stub.ts
+++ b/src/app/testing/stubs/mdm-resources/code-set-resource.stub.ts
@@ -1,0 +1,30 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { CodeSetDetailResponse, Uuid } from '@maurodatamapper/mdm-resources';
+import { Observable } from 'rxjs';
+
+export interface MdmCodeSetResourceStub {
+  get: jest.MockedFunction<(id: Uuid) => Observable<CodeSetDetailResponse>>;
+}
+
+export const createCodeSetStub = (): MdmCodeSetResourceStub => {
+  return {
+    get: jest.fn(),
+  };
+};

--- a/src/app/testing/stubs/mdm-resources/terminology-resource.stub.ts
+++ b/src/app/testing/stubs/mdm-resources/terminology-resource.stub.ts
@@ -1,0 +1,30 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { TerminologyDetailResponse, Uuid } from '@maurodatamapper/mdm-resources';
+import { Observable } from 'rxjs';
+
+export interface MdmTerminologyResourceStub {
+  get: jest.MockedFunction<(id: Uuid) => Observable<TerminologyDetailResponse>>;
+}
+
+export const createTerminologyStub = (): MdmTerminologyResourceStub => {
+  return {
+    get: jest.fn(),
+  };
+};

--- a/src/app/testing/stubs/terminology.stub.ts
+++ b/src/app/testing/stubs/terminology.stub.ts
@@ -1,0 +1,36 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import {
+  CatalogueItemDomainType,
+  TerminologyDetail,
+  Uuid,
+} from '@maurodatamapper/mdm-resources';
+import { Observable } from 'rxjs';
+
+export interface TerminologyServiceStub {
+  getModel: jest.MockedFunction<
+    (id: Uuid, domainType?: CatalogueItemDomainType) => Observable<TerminologyDetail>
+  >;
+}
+
+export const createTerminologyServiceStub = (): TerminologyServiceStub => {
+  return {
+    getModel: jest.fn(),
+  };
+};


### PR DESCRIPTION
- Hide missing description boxes
- Reduce cards to not need so many bold labels
- Support ModelDataType references to explain which model a type could be linked to
- Trim the returned profile to remove empty fields/sections

Resolves #200 

# Screenshots

![image](https://user-images.githubusercontent.com/3219480/212337557-9856f202-4828-4898-bb95-652d89a8a90c.png)

![image](https://user-images.githubusercontent.com/3219480/212337667-648479ae-fb62-4553-a957-4e3c80bbd374.png)

![image](https://user-images.githubusercontent.com/3219480/212337754-9ad1af07-f099-412f-8036-848fbd5d1220.png)
