### PR TITLE
gh-201 footer to be displayed at the bottom

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<div class="default-theme">
+<div class="default-theme page-container">
   <div class="mat-typography mdm-app-component">
     <mdm-header
       [logoLink]="logoLink"
@@ -33,11 +33,11 @@ SPDX-License-Identifier: Apache-2.0
       <router-outlet></router-outlet>
     </main>
 
-    <mdm-footer version="0.1.0" [links]="footerLinks"></mdm-footer>
-
     <mdm-loading-spinner
       *ngIf="isLoading"
       [caption]="loadingCaption"
     ></mdm-loading-spinner>
   </div>
+
+  <mdm-footer version="0.1.0" [links]="footerLinks"></mdm-footer>
 </div>

--- a/src/app/pages/my-request-detail/my-request-detail.component.html
+++ b/src/app/pages/my-request-detail/my-request-detail.component.html
@@ -138,17 +138,18 @@ SPDX-License-Identifier: Apache-2.0
       >
       </mdm-data-element-row>
 
-      <mat-checkbox (change)="onSelectAll($event)">Select all</mat-checkbox>
-      <button
-        class="ms-4"
-        mat-raised-button
-        color="primary"
-        [disabled]="removeSelectedButtonDisabled"
-        (click)="removeSelected()"
-      >
-        Remove selected ...
-      </button>
-      <div class="float-start mdm-my-request__request-elements-footer"></div>
+      <div class="mdm-my-request__request-elements-footer">
+        <mat-checkbox (change)="onSelectAll($event)">Select all</mat-checkbox>
+        <button
+          class="ms-4"
+          mat-raised-button
+          color="primary"
+          [disabled]="removeSelectedButtonDisabled"
+          (click)="removeSelected()"
+        >
+          Remove selected ...
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/src/styles/_home.scss
+++ b/src/styles/_home.scss
@@ -84,3 +84,14 @@ SPDX-License-Identifier: Apache-2.0
     font-size: 3.5em;
   }
 }
+
+body {
+  padding-bottom: 125px;
+}
+
+footer {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  height: 125px;
+}

--- a/src/styles/_home.scss
+++ b/src/styles/_home.scss
@@ -85,13 +85,18 @@ SPDX-License-Identifier: Apache-2.0
   }
 }
 
-body {
-  padding-bottom: 125px;
+.page-container {
+  position: relative;
+  min-height: 100vh;
+}
+
+.mdm-app-component {
+  padding-bottom: 7.9rem;
 }
 
 footer {
-  position: fixed;
+  position: absolute;
   bottom: 0;
   width: 100%;
-  height: 125px;
+  height: 7.9rem;
 }


### PR DESCRIPTION
CSS changes:
Fixing the position to the bottom. 
But with dynamic content, only with that caused that when rendering extra content, the footer was out of place, to solve this, fixed the height of the footer, and added bottom padding in the body. Now the footer is in position even when the body is too small or some content is added after the window loaded.
Closes #201 