### PR TITLE
fixed status chip

### DIFF
--- a/src/app/pages/my-request-detail/my-request-detail.component.html
+++ b/src/app/pages/my-request-detail/my-request-detail.component.html
@@ -60,6 +60,10 @@ SPDX-License-Identifier: Apache-2.0
         <p>{{ request.description }}</p>
         <mdm-request-status-chip [status]="request.status"></mdm-request-status-chip>
       </div>
+      <div *ngIf="!request.description" class="mdm-my-request__request-description">
+        <p>No description provided</p>
+        <mdm-request-status-chip [status]="request.status"></mdm-request-status-chip>
+      </div>
     </div>
 
     <div class="mdm-my-request__query--container">


### PR DESCRIPTION
Status chip was not present in request detail page when description was blank,
noticed in demo.
Boolean state fix