### PR TITLE
gh-204: Remove dataElements from queries when removing from request

### DIFF
--- a/src/app/data-explorer/data-requests.service.spec.ts
+++ b/src/app/data-explorer/data-requests.service.spec.ts
@@ -40,6 +40,7 @@ import {
   DataRequestQueryPayload,
   DataRequestQueryType,
   QueryCondition,
+  QueryExpression,
 } from '../data-explorer/data-explorer.types';
 import { createDataModelServiceStub } from '../testing/stubs/data-model.stub';
 import { createSecurityServiceStub } from '../testing/stubs/security.stub';
@@ -808,6 +809,119 @@ describe('DataRequestsService', () => {
 
       const expected$ = cold('---(a|)', { a: expected });
       const actual$ = service.createOrUpdateQuery(requestId, payload);
+      expect(actual$).toBeObservable(expected$);
+    });
+  });
+
+  describe('deleteDataElementsFromQuery', () => {
+    const requestId: Uuid = '1234';
+    const queryTypes: DataRequestQueryType[] = ['cohort', 'data'];
+    const expressions: QueryExpression[] = [
+      { field: 'field1', operator: '!=', value: 'value_field1' },
+      { field: 'field2', operator: '=', value: 'value_field2' },
+      { field: 'field3', operator: '<=', value: 'value_field3' },
+    ];
+    const condition: QueryCondition = { condition: 'and', rules: expressions };
+
+    it.each(queryTypes)('Should remove 1 data element correctly', (type) => {
+      const payload: DataRequestQueryPayload = {
+        ruleId: '456',
+        representationId: '789',
+        type,
+        condition,
+      };
+
+      const expectedExpressions: QueryExpression[] = [
+        { field: 'field2', operator: '=', value: 'value_field2' },
+        { field: 'field3', operator: '<=', value: 'value_field3' },
+      ];
+      const expectedCondition: QueryCondition = {
+        condition: 'and',
+        rules: expectedExpressions,
+      };
+
+      // Get query and createOrUpdateQuery has its own tests, so we can mock its dependency
+      // to unit test deleteDataElementsFromQuery
+      service.getQuery = jest.fn().mockReturnValueOnce(
+        cold('a|', {
+          a: payload,
+        })
+      );
+      service.createOrUpdateQuery = jest
+        .fn()
+        .mockImplementation((id: string, payload: DataRequestQueryPayload) => {
+          return cold('a|', {
+            a: {
+              ruleId: payload.ruleId,
+              representationId: payload.representationId,
+              type: payload.type,
+              condition: payload.condition,
+            },
+          });
+        });
+
+      const expected$ = cold('a|', {
+        a: {
+          ruleId: payload.ruleId,
+          representationId: payload.representationId,
+          type: type,
+          condition: expectedCondition,
+        },
+      });
+
+      const actual$ = service.deleteDataElementsFromQuery(requestId, type, ['field1']);
+      expect(actual$).toBeObservable(expected$);
+    });
+
+    it.each(queryTypes)('Should remove multiple data element correctly', (type) => {
+      const payload: DataRequestQueryPayload = {
+        ruleId: '456',
+        representationId: '789',
+        type,
+        condition,
+      };
+
+      const expectedExpressions: QueryExpression[] = [
+        { field: 'field2', operator: '=', value: 'value_field2' },
+      ];
+      const expectedCondition: QueryCondition = {
+        condition: 'and',
+        rules: expectedExpressions,
+      };
+
+      // Get query and createOrUpdateQuery has its own tests, so we can mock its dependency
+      // to unit test deleteDataElementsFromQuery
+      service.getQuery = jest.fn().mockReturnValueOnce(
+        cold('a|', {
+          a: payload,
+        })
+      );
+      service.createOrUpdateQuery = jest
+        .fn()
+        .mockImplementation((id: string, payload: DataRequestQueryPayload) => {
+          return cold('a|', {
+            a: {
+              ruleId: payload.ruleId,
+              representationId: payload.representationId,
+              type: payload.type,
+              condition: payload.condition,
+            },
+          });
+        });
+
+      const expected$ = cold('a|', {
+        a: {
+          ruleId: payload.ruleId,
+          representationId: payload.representationId,
+          type: type,
+          condition: expectedCondition,
+        },
+      });
+
+      const actual$ = service.deleteDataElementsFromQuery(requestId, type, [
+        'field1',
+        'field3',
+      ]);
       expect(actual$).toBeObservable(expected$);
     });
   });

--- a/src/app/data-explorer/data-requests.service.spec.ts
+++ b/src/app/data-explorer/data-requests.service.spec.ts
@@ -824,7 +824,7 @@ describe('DataRequestsService', () => {
     const condition: QueryCondition = { condition: 'and', rules: expressions };
 
     it.each(queryTypes)('Should remove 1 data element correctly', (type) => {
-      const payload: DataRequestQueryPayload = {
+      const queryPayload: DataRequestQueryPayload = {
         ruleId: '456',
         representationId: '789',
         type,
@@ -844,7 +844,7 @@ describe('DataRequestsService', () => {
       // to unit test deleteDataElementsFromQuery
       service.getQuery = jest.fn().mockReturnValueOnce(
         cold('a|', {
-          a: payload,
+          a: queryPayload,
         })
       );
       service.createOrUpdateQuery = jest
@@ -862,9 +862,9 @@ describe('DataRequestsService', () => {
 
       const expected$ = cold('a|', {
         a: {
-          ruleId: payload.ruleId,
-          representationId: payload.representationId,
-          type: type,
+          ruleId: queryPayload.ruleId,
+          representationId: queryPayload.representationId,
+          type,
           condition: expectedCondition,
         },
       });
@@ -874,7 +874,7 @@ describe('DataRequestsService', () => {
     });
 
     it.each(queryTypes)('Should remove multiple data element correctly', (type) => {
-      const payload: DataRequestQueryPayload = {
+      const queryPayload: DataRequestQueryPayload = {
         ruleId: '456',
         representationId: '789',
         type,
@@ -893,7 +893,7 @@ describe('DataRequestsService', () => {
       // to unit test deleteDataElementsFromQuery
       service.getQuery = jest.fn().mockReturnValueOnce(
         cold('a|', {
-          a: payload,
+          a: queryPayload,
         })
       );
       service.createOrUpdateQuery = jest
@@ -911,9 +911,9 @@ describe('DataRequestsService', () => {
 
       const expected$ = cold('a|', {
         a: {
-          ruleId: payload.ruleId,
-          representationId: payload.representationId,
-          type: type,
+          ruleId: queryPayload.ruleId,
+          representationId: queryPayload.representationId,
+          type,
           condition: expectedCondition,
         },
       });

--- a/src/app/data-explorer/data-requests.service.ts
+++ b/src/app/data-explorer/data-requests.service.ts
@@ -515,14 +515,14 @@ export class DataRequestsService {
    *
    * @param requestId The unique identifier of the data request.
    * @param type The type of query to get.
-   * @param dataElementLabel the label of the data element to remove from the query.
+   * @param dataElementLabels the labels of the data elements to remove from the query.
    * @returns a {@link DataRequestQueryPayload} with the query after removing the
    * data elements, or empty if the request or query cannot be found.
    */
   deleteDataElementsFromQuery(
     requestId: Uuid,
     type: DataRequestQueryType,
-    dataElementLabel: string
+    dataElementLabels: string[]
   ): Observable<DataRequestQueryPayload> {
     let updatedQuery: DataRequestQueryPayload;
 
@@ -534,9 +534,11 @@ export class DataRequestsService {
 
         updatedQuery = query;
 
-        updatedQuery.condition.rules = query.condition.rules.filter(
-          (item) => !(item as QueryExpression)?.field?.startsWith(dataElementLabel)
-        );
+        dataElementLabels.forEach((label) => {
+          updatedQuery.condition.rules = query.condition.rules.filter(
+            (item) => !(item as QueryExpression)?.field?.startsWith(label)
+          );
+        });
 
         return this.createOrUpdateQuery(requestId, updatedQuery);
       })

--- a/src/app/data-explorer/data-requests.service.ts
+++ b/src/app/data-explorer/data-requests.service.ts
@@ -43,7 +43,6 @@ import {
   switchMap,
   throwError,
   from,
-  empty,
 } from 'rxjs';
 import { UserDetails } from '../security/user-details.service';
 import { DataModelService } from '../mauro/data-model.service';
@@ -510,8 +509,7 @@ export class DataRequestsService {
   }
 
   /**
-   * Removes all rules containing the data element label. And returns
-   * the new value of the query.
+   * Removes all data labels found in a query attached to a data request.
    *
    * @param requestId The unique identifier of the data request.
    * @param type The type of query to get.

--- a/src/app/pages/my-request-detail/my-request-detail.component.spec.ts
+++ b/src/app/pages/my-request-detail/my-request-detail.component.spec.ts
@@ -504,8 +504,21 @@ describe('MyRequestsComponent', () => {
         ],
         failures: [],
       };
+
+      const deleteFromQueryResult: DataRequestQueryPayload = {
+        ruleId: 'id1',
+        representationId: 'representationId1',
+        type: 'cohort',
+        condition: {
+          condition: 'and',
+          rules: [],
+        },
+      };
       dataRequestsStub.deleteDataElementMultiple.mockReset();
       dataRequestsStub.deleteDataElementMultiple.mockReturnValue(of(deleteResult));
+      dataRequestsStub.deleteDataElementsFromQuery.mockReturnValue(
+        of(deleteFromQueryResult)
+      );
       broadcastStub.loading.mockReset();
 
       // Pretend to delete first element
@@ -518,6 +531,7 @@ describe('MyRequestsComponent', () => {
       // check the fallout
       expect(dialogsStub.open).toHaveBeenCalledTimes(1);
       expect(broadcastStub.loading).toHaveBeenCalledTimes(2);
+      expect(dataRequestsStub.deleteDataElementsFromQuery).toBeCalledTimes(2);
       expect(dataRequestsStub.deleteDataElementMultiple).toHaveBeenCalledTimes(1);
       expect(dataRequestsStub.deleteDataElementMultiple.mock.calls[0][0]).toStrictEqual([
         selectableElements()[0],

--- a/src/app/testing/stubs/data-requests.stub.ts
+++ b/src/app/testing/stubs/data-requests.stub.ts
@@ -70,6 +70,11 @@ export type DataRequestsUpdateRequestsFolderFn = (
 ) => Observable<[DataModel, string[]]>;
 export type DataRequestGetRequestsFolderFn = () => Observable<FolderDetail>;
 export type DataRequestGetFolderNameFn = (userEmail: string) => string;
+export type DeleteDataElementsFromQueryFn = (
+  requestId: Uuid,
+  type: DataRequestQueryType,
+  dataElementLabels: string[]
+) => Observable<DataRequestQueryPayload>;
 
 export interface DataRequestsServiceStub {
   get: jest.MockedFunction<(id: Uuid) => Observable<DataRequest>>;
@@ -88,6 +93,7 @@ export interface DataRequestsServiceStub {
   createOrUpdateQuery: jest.MockedFunction<
     (requestId: string, payload: DataRequestQueryPayload) => Observable<DataRequestQuery>
   >;
+  deleteDataElementsFromQuery: jest.MockedFunction<DeleteDataElementsFromQueryFn>;
 }
 
 export const createDataRequestsServiceStub = (): DataRequestsServiceStub => {
@@ -109,5 +115,7 @@ export const createDataRequestsServiceStub = (): DataRequestsServiceStub => {
       jest.fn() as jest.MockedFunction<DataRequestGetFolderNameFn>,
     getQuery: jest.fn(),
     createOrUpdateQuery: jest.fn(),
+    deleteDataElementsFromQuery:
+      jest.fn() as jest.MockedFunction<DeleteDataElementsFromQueryFn>,
   };
 };


### PR DESCRIPTION
Added new method `deleteDataElementsFromQuery `on service `data-requests.service`.
Refactoring `removeItem `and `removeSelected `so both use the same code of `removeOneOrMoreDataElements `in `my-request-detail.component`

Adding and fixing tests for the new methods.

closes #204 