### PR TITLE
gh-203 Create pages to view and create requests from templates

### DIFF
--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -112,3 +112,17 @@ Once happy with the collection of data elements gathered, the user will be able 
 At this point, the Mauro Data Explorer does not handle the submitted request anymore, the request for data access now falls under the control/responsibility of the hosting organisation.
 
 It is possible for a user to create a new version of a previously submitted request, using the same [versioning](https://maurodatamapper.github.io/user-guides/branch-version-fork/branch-version-fork/) mechanisms that all data models have. This will create a new draft version which can be modified again before being submitted (finalised) a second time.
+
+# Template Requests
+
+Instead of creating User Requests from scratch, it is possible to base a request off of a _template_. This is a pre-made request that is finalised and can be forked to make a copy from.
+
+## Templates Folder
+
+The `mdm-plugin-explorer` will automatically:
+
+1. Bootstrap a folder in Mauro called "Mauro Explorer Templates"
+2. Secure this folder to only be read by the "Explorer Readers" user group.
+3. Install the API property `explorer.config.root_-_template_folder` pointing to this folder.
+
+This will be the root folder to store any finalised template requests. The Mauro Data Explorer `/templates` page route will list all available templates and allow the user to inspect them and copy from them. Copying involves forking the Data Model request to build the copy, which is then automatically moved to the current user's personal request folder.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -10,6 +10,7 @@ The [mdm-plugin-explorer](https://github.com/MauroDataMapper-Plugins/mdm-plugin-
 
 - `explorer.config.root_data_model_path`
 - `explorer.config.root_request_folder`
+- `explorer.config.root_template_folder`
 - `explorer.config.profile_namespace`
 - `explorer.config.profile_service_name`
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -103,6 +103,11 @@ export class AppComponent implements OnInit, OnDestroy {
       onlySignedIn: true,
     },
     {
+      label: 'Templates',
+      routerLink: '/templates',
+      onlySignedIn: true,
+    },
+    {
       label: 'Help',
       routerLink: '/help',
       arrow: 'angle-down',

--- a/src/app/data-explorer/data-element-search-result/data-element-search-result.component.html
+++ b/src/app/data-explorer/data-element-search-result/data-element-search-result.component.html
@@ -46,6 +46,12 @@ SPDX-License-Identifier: Apache-2.0
       <div *ngIf="item.description" class="mdm-data-element-search-result__description">
         {{ item.description }}
       </div>
+      <div
+        *ngIf="!item.description"
+        class="mdm-data-element-search-result__no-description"
+      >
+        No description available
+      </div>
       <div class="mdm-data-element-search-result__footer">
         <span class="spacer"></span>
         <mdm-identifiable-data-icon

--- a/src/app/data-explorer/data-element-search-result/data-element-search-result.component.html
+++ b/src/app/data-explorer/data-element-search-result/data-element-search-result.component.html
@@ -16,40 +16,42 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<div *ngIf="item" class="highlight-box mdm-data-element-search-result">
-  <div class="mdm-data-element-search-result__header">
-    <span>
-      <mat-checkbox (change)="itemChecked($event)" [checked]="item.isSelected">
-      </mat-checkbox>
-      <h3>
+<mdm-header-and-content-box *ngIf="item">
+  <div header-title class="mdm-data-element-search-result__header">
+    <mat-checkbox (change)="itemChecked($event)" [checked]="item.isSelected">
+    </mat-checkbox>
+    <h3>
+      <a [routerLink]="['/dataElement', item.model, item.dataClass, item.id]">
         {{ item.label }}
-      </h3>
-      <mdm-breadcrumb
-        *ngIf="showBreadcrumb"
-        class="mdm-data-element-search-result__header__breadcrumb"
-        [item]="item"
-      ></mdm-breadcrumb>
-    </span>
-    <span>
-      <mdm-data-element-in-request
-        [dataElement]="item"
-        [sourceTargetIntersections]="sourceTargetIntersections"
-      ></mdm-data-element-in-request>
-      <mdm-bookmark-toggle
-        (toggle)="toggleBookmark($event)"
-        [selected]="isBookmarked"
-      ></mdm-bookmark-toggle>
-    </span>
+      </a>
+    </h3>
+    <mdm-breadcrumb
+      *ngIf="showBreadcrumb"
+      class="mdm-data-element-search-result__header__breadcrumb"
+      [item]="item"
+    ></mdm-breadcrumb>
   </div>
-  <div *ngIf="item.description" class="mdm-data-element-search-result__content">
-    {{ item.description }}
-  </div>
-  <div class="mdm-data-element-search-result__footer">
-    <a [routerLink]="['/dataElement', item.model, item.dataClass, item.id]"
-      >View Details</a
-    >
-    <mdm-identifiable-data-icon
-      [state]="item.identifiableData"
-    ></mdm-identifiable-data-icon>
-  </div>
-</div>
+  <ng-container header-actions>
+    <mdm-data-element-in-request
+      [dataElement]="item"
+      [sourceTargetIntersections]="sourceTargetIntersections"
+    ></mdm-data-element-in-request>
+    <mdm-bookmark-toggle
+      (toggle)="toggleBookmark($event)"
+      [selected]="isBookmarked"
+    ></mdm-bookmark-toggle>
+  </ng-container>
+  <ng-container>
+    <div class="mdm-data-element-search-result__content">
+      <div *ngIf="item.description" class="mdm-data-element-search-result__description">
+        {{ item.description }}
+      </div>
+      <div class="mdm-data-element-search-result__footer">
+        <span class="spacer"></span>
+        <mdm-identifiable-data-icon
+          [state]="item.identifiableData"
+        ></mdm-identifiable-data-icon>
+      </div>
+    </div>
+  </ng-container>
+</mdm-header-and-content-box>

--- a/src/app/data-explorer/data-element-search-result/data-element-search-result.component.scss
+++ b/src/app/data-explorer/data-element-search-result/data-element-search-result.component.scss
@@ -23,7 +23,7 @@ $search-result-heading-color: $color-white;
 $search-result-header-padding: 0.2em 1.2em;
 
 $search-result-content-color: $color-mauro-light-gold;
-$search-result-content-padding: 1.2em 1.2em;
+$search-result-content-padding: 0.2em 0;
 
 $search-result-border-radius: 4px;
 
@@ -36,7 +36,6 @@ $search-result-border-radius: 4px;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: $search-result-header-padding;
     background-color: $search-result-heading-background-color;
     color: $search-result-heading-color;
     border-radius: $search-result-border-radius;
@@ -46,6 +45,10 @@ $search-result-border-radius: 4px;
       font-weight: 500;
       margin: 0 1em;
       vertical-align: middle;
+
+      a {
+        color: $search-result-heading-color;
+      }
     }
 
     &__breadcrumb {
@@ -54,7 +57,12 @@ $search-result-border-radius: 4px;
     }
   }
 
-  &__content,
+  &__content {
+    display: block;
+    width: 100%;
+  }
+
+  &__description,
   &__footer {
     padding: $search-result-content-padding;
     background-color: $search-result-content-color;

--- a/src/app/data-explorer/data-element-search-result/data-element-search-result.component.scss
+++ b/src/app/data-explorer/data-element-search-result/data-element-search-result.component.scss
@@ -70,4 +70,8 @@ $search-result-border-radius: 4px;
     justify-content: space-between;
     border-radius: $search-result-border-radius;
   }
+
+  &__no-description {
+    font-style: italic;
+  }
 }

--- a/src/app/data-explorer/data-explorer.module.ts
+++ b/src/app/data-explorer/data-explorer.module.ts
@@ -40,6 +40,8 @@ import { QueryBuilderComponent } from '../data-explorer/querybuilder/querybuilde
 import { QueryBuilderModule } from 'angular2-query-builder';
 import { MeqlPipe } from './pipes/meql.pipe';
 import { MeqlOutputComponent } from './meql-output/meql-output.component';
+import { DataRequestRowComponent } from './data-request-row/data-request-row.component';
+import { DataQueryRowComponent } from './data-query-row/data-query-row.component';
 
 @NgModule({
   declarations: [
@@ -62,6 +64,8 @@ import { MeqlOutputComponent } from './meql-output/meql-output.component';
     QueryBuilderComponent,
     MeqlPipe,
     MeqlOutputComponent,
+    DataRequestRowComponent,
+    DataQueryRowComponent,
   ],
   imports: [CoreModule, SharedModule, QueryBuilderModule],
   exports: [
@@ -78,6 +82,8 @@ import { MeqlOutputComponent } from './meql-output/meql-output.component';
     CatalogueSearchFormComponent,
     QueryBuilderComponent,
     MeqlOutputComponent,
+    DataRequestRowComponent,
+    DataQueryRowComponent,
   ],
   providers: [
     {

--- a/src/app/data-explorer/data-explorer.types.ts
+++ b/src/app/data-explorer/data-explorer.types.ts
@@ -24,6 +24,7 @@ import {
   DataElement,
   DataModel,
   DataType,
+  Folder,
   ProfileField,
   ProfileSearchResult,
   ProfileSearchResultField,
@@ -363,3 +364,7 @@ export interface QueryCondition {
 }
 
 export type QueryRule = QueryExpression | QueryCondition;
+
+export interface ForkDataRequestOptions {
+  targetFolder?: Folder;
+}

--- a/src/app/data-explorer/data-query-row/data-query-row.component.html
+++ b/src/app/data-explorer/data-query-row/data-query-row.component.html
@@ -1,0 +1,47 @@
+<!--
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+<mdm-header-and-content-box *ngIf="queryType && condition">
+  <h3 header-title class="m-0">{{ label }}</h3>
+  <ng-container header-actions>
+    <a
+      *ngIf="!readOnly && canCreate"
+      mat-raised-button
+      color="primary"
+      [routerLink]="createRouterLink"
+    >
+      <span class="fa-solid fa-plus"></span>
+      Create
+    </a>
+    <a
+      *ngIf="!readOnly && canEdit"
+      mat-raised-button
+      color="primary"
+      [routerLink]="editRouterLink"
+    >
+      <span class="fa-solid fa-pen-to-square"></span>
+      Edit
+    </a>
+  </ng-container>
+  <ng-container *ngIf="condition.rules.length > 0">
+    <mdm-meql-output [query]="condition" class="full-width"></mdm-meql-output>
+  </ng-container>
+  <ng-container *ngIf="condition.rules.length === 0">
+    <p>No query has been defined.</p>
+  </ng-container>
+</mdm-header-and-content-box>

--- a/src/app/data-explorer/data-query-row/data-query-row.component.scss
+++ b/src/app/data-explorer/data-query-row/data-query-row.component.scss
@@ -1,0 +1,18 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/

--- a/src/app/data-explorer/data-query-row/data-query-row.component.spec.ts
+++ b/src/app/data-explorer/data-query-row/data-query-row.component.spec.ts
@@ -1,0 +1,108 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import {
+  ComponentHarness,
+  setupTestModuleForComponent,
+} from 'src/app/testing/testing.helpers';
+import { DataRequestQueryType } from '../data-explorer.types';
+
+import { DataQueryRowComponent } from './data-query-row.component';
+
+describe('DataQueryRowComponent', () => {
+  let harness: ComponentHarness<DataQueryRowComponent>;
+
+  beforeEach(async () => {
+    harness = await setupTestModuleForComponent(DataQueryRowComponent);
+  });
+
+  it('should create', () => {
+    expect(harness.isComponentCreated).toBeTruthy();
+    expect(harness.component.queryType).toBeUndefined();
+    expect(harness.component.condition).toBeUndefined();
+    expect(harness.component.readOnly).toBe(false);
+    expect(harness.component.createRouterLink).toBeUndefined();
+    expect(harness.component.editRouterLink).toBeUndefined();
+  });
+
+  it.each<[DataRequestQueryType | undefined, string | null]>([
+    ['cohort', 'Cohort query'],
+    ['data', 'Data query'],
+    [undefined, null],
+  ])('should use type %p to use label %p', (type, expected) => {
+    harness.component.queryType = type;
+    const actual = harness.component.label;
+    expect(actual).toBe(expected);
+  });
+
+  it('should allow create button when no query is set', () => {
+    expect(harness.component.canCreate).toBe(true);
+  });
+
+  it('should allow create button when a query has no rules', () => {
+    harness.component.condition = {
+      condition: 'and',
+      rules: [],
+    };
+
+    expect(harness.component.canCreate).toBe(true);
+  });
+
+  it('should not allow create button when a query has at least one rule', () => {
+    harness.component.condition = {
+      condition: 'and',
+      rules: [
+        {
+          field: 'test',
+          operator: '=',
+          value: 'test',
+        },
+      ],
+    };
+
+    expect(harness.component.canCreate).toBe(false);
+  });
+
+  it('should allow edit button when a query has at least one rule', () => {
+    harness.component.condition = {
+      condition: 'and',
+      rules: [
+        {
+          field: 'test',
+          operator: '=',
+          value: 'test',
+        },
+      ],
+    };
+
+    expect(harness.component.canEdit).toBe(true);
+  });
+
+  it('should not allow edit button when no query is set', () => {
+    expect(harness.component.canEdit).toBeFalsy();
+  });
+
+  it('should not allow edit button when a query has no rules', () => {
+    harness.component.condition = {
+      condition: 'and',
+      rules: [],
+    };
+
+    expect(harness.component.canEdit).toBe(false);
+  });
+});

--- a/src/app/data-explorer/data-query-row/data-query-row.component.ts
+++ b/src/app/data-explorer/data-query-row/data-query-row.component.ts
@@ -1,0 +1,50 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Component, Input } from '@angular/core';
+import { RouterLinkRef } from 'src/app/shared/types/shared.types';
+import { DataRequestQueryType, QueryCondition } from '../data-explorer.types';
+
+@Component({
+  selector: 'mdm-data-query-row',
+  templateUrl: './data-query-row.component.html',
+  styleUrls: ['./data-query-row.component.scss'],
+})
+export class DataQueryRowComponent {
+  @Input() queryType?: DataRequestQueryType;
+  @Input() condition?: QueryCondition;
+  @Input() readOnly = false;
+  @Input() createRouterLink?: RouterLinkRef;
+  @Input() editRouterLink?: RouterLinkRef;
+
+  get label() {
+    return this.queryType === 'cohort'
+      ? 'Cohort query'
+      : this.queryType === 'data'
+      ? 'Data query'
+      : null;
+  }
+
+  get canCreate() {
+    return !this.condition || this.condition.rules.length === 0;
+  }
+
+  get canEdit() {
+    return this.condition && this.condition.rules.length > 0;
+  }
+}

--- a/src/app/data-explorer/data-request-row/data-request-row.component.html
+++ b/src/app/data-explorer/data-request-row/data-request-row.component.html
@@ -1,0 +1,57 @@
+<!--
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+<mdm-header-and-content-box *ngIf="request">
+  <h3 header-title class="header-title">
+    <a *ngIf="showLabel" [routerLink]="detailsRouterLink">
+      {{ request.label }}
+    </a>
+  </h3>
+  <ng-container header-actions>
+    <button
+      *ngIf="showSubmitButton"
+      mat-raised-button
+      color="primary"
+      (click)="onSubmitClick()"
+    >
+      <span class="fa-solid fa-paper-plane"></span>
+      Submit
+    </button>
+    <button
+      *ngIf="showCopyButton"
+      mat-raised-button
+      color="primary"
+      (click)="onCopyClick()"
+    >
+      <span class="fa-solid fa-copy"></span>
+      Copy
+    </button>
+  </ng-container>
+  <ng-container>
+    <div *ngIf="request.description">
+      <p>{{ request.description }}</p>
+    </div>
+    <div *ngIf="!request.description">
+      <p>No description provided</p>
+    </div>
+    <mdm-request-status-chip
+      *ngIf="showStatus"
+      [status]="request.status"
+    ></mdm-request-status-chip>
+  </ng-container>
+</mdm-header-and-content-box>

--- a/src/app/data-explorer/data-request-row/data-request-row.component.scss
+++ b/src/app/data-explorer/data-request-row/data-request-row.component.scss
@@ -1,0 +1,18 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/

--- a/src/app/data-explorer/data-request-row/data-request-row.component.spec.ts
+++ b/src/app/data-explorer/data-request-row/data-request-row.component.spec.ts
@@ -1,0 +1,54 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import {
+  ComponentHarness,
+  setupTestModuleForComponent,
+} from 'src/app/testing/testing.helpers';
+
+import { DataRequestRowComponent } from './data-request-row.component';
+
+describe('DataRequestRowComponent', () => {
+  let harness: ComponentHarness<DataRequestRowComponent>;
+
+  beforeEach(async () => {
+    harness = await setupTestModuleForComponent(DataRequestRowComponent);
+  });
+
+  it('should create', () => {
+    expect(harness.isComponentCreated).toBeTruthy();
+    expect(harness.component.request).toBeUndefined();
+    expect(harness.component.detailsRouterLink).toBeUndefined();
+    expect(harness.component.showStatus).toBe(true);
+    expect(harness.component.showLabel).toBe(true);
+    expect(harness.component.showSubmitButton).toBe(false);
+    expect(harness.component.showCopyButton).toBe(false);
+  });
+
+  it('should raise the submit click event', () => {
+    const spy = jest.spyOn(harness.component.submitClick, 'emit');
+    harness.component.onSubmitClick();
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should raise the copy click event', () => {
+    const spy = jest.spyOn(harness.component.copyClick, 'emit');
+    harness.component.onCopyClick();
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/src/app/data-explorer/data-request-row/data-request-row.component.ts
+++ b/src/app/data-explorer/data-request-row/data-request-row.component.ts
@@ -1,0 +1,46 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { RouterLinkRef } from 'src/app/shared/types/shared.types';
+import { DataRequest } from '../data-explorer.types';
+
+@Component({
+  selector: 'mdm-data-request-row',
+  templateUrl: './data-request-row.component.html',
+  styleUrls: ['./data-request-row.component.scss'],
+})
+export class DataRequestRowComponent {
+  @Input() request?: DataRequest;
+  @Input() detailsRouterLink?: RouterLinkRef;
+  @Input() showStatus = true;
+  @Input() showLabel = true;
+  @Input() showSubmitButton = false;
+  @Input() showCopyButton = false;
+
+  @Output() submitClick = new EventEmitter<void>();
+  @Output() copyClick = new EventEmitter<void>();
+
+  onSubmitClick() {
+    this.submitClick.emit();
+  }
+
+  onCopyClick() {
+    this.copyClick.emit();
+  }
+}

--- a/src/app/mauro/data-model.service.spec.ts
+++ b/src/app/mauro/data-model.service.spec.ts
@@ -27,6 +27,7 @@ import {
   DataModelFull,
   DataModelSubsetPayload,
   SearchQueryParameters,
+  Uuid,
 } from '@maurodatamapper/mdm-resources';
 import { cold } from 'jest-marbles';
 import { DataElementDto } from '../data-explorer/data-explorer.types';
@@ -457,6 +458,30 @@ describe('DataModelService', () => {
 
       const expected$ = cold('--a|', { a: dataModel });
       const actual$ = service.addToFolder(folderId, payload);
+      expect(actual$).toBeObservable(expected$);
+    });
+  });
+
+  describe('move to folder', () => {
+    it('should return a data model', () => {
+      const folderId: Uuid = '1';
+      const dataModel: DataModelDetail = {
+        id: '2',
+        label: 'test',
+        domainType: CatalogueItemDomainType.DataModel,
+        availableActions: ['show'],
+        finalised: false,
+      };
+
+      endpointsStub.dataModel.moveDataModelToFolder.mockImplementationOnce((mId, fId) => {
+        expect(mId).toBe(dataModel.id);
+        expect(fId).toBe(folderId);
+        return cold('--a|', { a: { body: dataModel } });
+      });
+
+      const expected$ = cold('--a|', { a: dataModel });
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const actual$ = service.moveToFolder(dataModel.id!, folderId);
       expect(actual$).toBeObservable(expected$);
     });
   });

--- a/src/app/mauro/data-model.service.ts
+++ b/src/app/mauro/data-model.service.ts
@@ -228,6 +228,19 @@ export class DataModelService {
   }
 
   /**
+   * Moves a data model to a target folder.
+   *
+   * @param modelId The ID of the data model to move.
+   * @param targetFolderId The ID of the folder to move to.
+   * @returns An observable of {@link DataModelDetail} object just moved.
+   */
+  moveToFolder(modelId: Uuid, targetFolderId: Uuid): Observable<DataModelDetail> {
+    return this.endpoints.dataModel
+      .moveDataModelToFolder(modelId, targetFolderId, {})
+      .pipe(map((response: DataModelDetailResponse) => response.body));
+  }
+
+  /**
    * Copy a subset of a Data Model to another Data Model. Define which Data Elements to add/remove and the related
    * schema will also be copied to the target as well.
    *

--- a/src/app/mauro/plugins/plugin-research.resource.ts
+++ b/src/app/mauro/plugins/plugin-research.resource.ts
@@ -21,6 +21,7 @@ import {
   MdmResourcesConfiguration,
   MdmResponse,
   MdmRestHandler,
+  QueryParameters,
   RequestSettings,
   Uuid,
 } from '@maurodatamapper/mdm-resources';
@@ -83,5 +84,18 @@ export class MdmPluginResearchResource extends MdmResource {
   userFolder(options?: RequestSettings) {
     const url = `${this.apiEndpoint}/explorer/userFolder`;
     return this.simplePost(url, null, options);
+  }
+
+  /**
+   * `HTTP GET` - Get the root folder where template requests are held.
+   *
+   * @param options Optional REST handler parameters, if required.
+   * @returns The result of the `POST` request:
+   *
+   * `200 OK` - will return an folder detail response. The HTTP status explains that it was successful.
+   */
+  templateFolder(query?: QueryParameters, options?: RequestSettings) {
+    const url = `${this.apiEndpoint}/explorer/templateFolder`;
+    return this.simpleGet(url, query, options);
   }
 }

--- a/src/app/mauro/research-plugin.service.ts
+++ b/src/app/mauro/research-plugin.service.ts
@@ -55,4 +55,10 @@ export class ResearchPluginService {
       .userFolder()
       .pipe(map((response: FolderDetailResponse) => response.body));
   }
+
+  templateFolder(): Observable<FolderDetail> {
+    return this.endpoints.pluginResearch
+      .templateFolder()
+      .pipe(map((response: FolderDetailResponse) => response.body));
+  }
 }

--- a/src/app/pages/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/dashboard.component.html
@@ -59,12 +59,16 @@ SPDX-License-Identifier: Apache-2.0
       <p>
         You will find your active projects here, which organises our data points you are
         interested in for your own research. You can then submit these to us to request
-        permission for our data. <a routerLink="/search">Search</a> or
-        <a routerLink="/browse">browse</a> our catalogue to identify further data points
-        of interest.
+        permission for our data.
+      </p>
+      <p>
+        <a routerLink="/search">Search</a> or <a routerLink="/browse">browse</a> our
+        catalogue to identify further data points of interest. You can also use our
+        <a routerLink="/templates">request templates</a>, curated to represent common
+        scenarios, as a starting point for your own data requests.
       </p>
       <p *ngIf="currentUserRequests.length === 0" class="text-center">
-        No active requests yet? Search the catalogue to start...
+        No active requests yet? Search the catalogue to start, or review our templates.
       </p>
       <div *ngIf="currentUserRequests.length > 0">
         <p-carousel [value]="currentUserRequests" [numVisible]="3" [numScroll]="3">

--- a/src/app/pages/my-request-detail/my-request-detail.component.html
+++ b/src/app/pages/my-request-detail/my-request-detail.component.html
@@ -21,110 +21,40 @@ SPDX-License-Identifier: Apache-2.0
     <div class="main-row hero">
       <h1>{{ request.label }}</h1>
     </div>
+    <mdm-back-link routerLink="/requests" label="Back to My Requests"></mdm-back-link>
     <div *ngIf="state === 'loading'" class="mdm-my-request__progress">
       <mat-progress-bar color="primary" mode="indeterminate"></mat-progress-bar>
     </div>
-    <div class="mdm-my-request__back-link">
-      <a [routerLink]="backRouterLink">
-        <span class="fa-solid fa-arrow-left"></span>
-        {{ backLabel }}
-      </a>
-    </div>
     <div class="col">
-      <div class="mdm-my-request__request-header">
-        <div class="mdm-my-request__request-header-title">
-          <div class="mdm-my-request__request-header--name">
-            <div class="mdm-my-request__request-header--buttons">
-              <button
-                *ngIf="request.status === 'submitted'"
-                mat-raised-button
-                matTooltip="Create a new request based on this one and make modifications."
-                (click)="copyRequest()"
-              >
-                Copy
-              </button>
-              <button
-                *ngIf="request.status === 'unsent'"
-                mat-raised-button
-                (click)="submitRequest()"
-              >
-                Submit request
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="mdm-my-request__request-description-container">
-      <div *ngIf="request.description" class="mdm-my-request__request-description">
-        <p>{{ request.description }}</p>
-        <mdm-request-status-chip [status]="request.status"></mdm-request-status-chip>
-      </div>
-      <div *ngIf="!request.description" class="mdm-my-request__request-description">
-        <p>No description provided</p>
-        <mdm-request-status-chip [status]="request.status"></mdm-request-status-chip>
-      </div>
+      <mdm-data-request-row
+        [request]="request"
+        [showLabel]="false"
+        [showStatus]="true"
+        [showSubmitButton]="request.status === 'unsent'"
+        [showCopyButton]="request.status === 'submitted'"
+        (submitClick)="submitRequest()"
+        (copyClick)="copyRequest()"
+      ></mdm-data-request-row>
     </div>
 
-    <div class="mdm-my-request__query--container">
-      <div class="mdm-my-request__query">
-        <div class="row">
-          <div
-            *ngIf="this.cohortQuery.rules.length > 0"
-            class="mdm-my-request__query-cohort"
-          >
-            <h2>Cohort Query</h2>
+    <h2>Queries</h2>
 
-            <mdm-meql-output [query]="cohortQuery"></mdm-meql-output>
-          </div>
-          <div class="mdm-my-request__query--description">
-            <div
-              *ngIf="this.cohortQuery.rules.length == 0"
-              class="mdm-my-request__query-missing"
-            >
-              <p>No Cohort Query has been created for this request</p>
-            </div>
-            <div class="mdm-my-request__query--description-buttons">
-              <a
-                *ngIf="this.showCohortCreate()"
-                [routerLink]="['queries/', cohortQueryType]"
-                ><button mat-raised-button>Create Cohort Query</button></a
-              >
-              <a
-                *ngIf="this.showCohortEdit()"
-                [routerLink]="['queries/', cohortQueryType]"
-                ><button mat-raised-button>Edit Cohort Query</button></a
-              >
-            </div>
-          </div>
-        </div>
+    <mdm-data-query-row
+      queryType="cohort"
+      [condition]="cohortQuery"
+      [readOnly]="request.status === 'submitted'"
+      createRouterLink="queries/cohort"
+      editRouterLink="queries/cohort"
+    ></mdm-data-query-row>
+    <mdm-data-query-row
+      queryType="data"
+      [condition]="dataQuery"
+      [readOnly]="request.status === 'submitted'"
+      createRouterLink="queries/data"
+      editRouterLink="queries/data"
+    ></mdm-data-query-row>
 
-        <div class="row">
-          <div *ngIf="this.dataQuery.rules.length > 0" class="mdm-my-request__query-data">
-            <h2>Data Query</h2>
-            <mdm-meql-output [query]="dataQuery"></mdm-meql-output>
-          </div>
-
-          <div class="mdm-my-request__query--description">
-            <div
-              *ngIf="this.dataQuery.rules.length == 0"
-              class="mdm-my-request__query-missing"
-            >
-              <p>No Data Query has been created for this request</p>
-            </div>
-
-            <div class="mdm-my-request__query--description-buttons">
-              <a *ngIf="this.showDataCreate()" [routerLink]="['queries/', dataQueryType]"
-                ><button mat-raised-button>Create Data Query</button></a
-              >
-              <a *ngIf="this.showDataEdit()" [routerLink]="['queries/', dataQueryType]"
-                ><button mat-raised-button>Edit Data Query</button></a
-              >
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+    <h2>Data elements</h2>
 
     <div
       class="mdm-my-request__request-elements"

--- a/src/app/pages/my-request-detail/my-request-detail.component.scss
+++ b/src/app/pages/my-request-detail/my-request-detail.component.scss
@@ -18,126 +18,11 @@ SPDX-License-Identifier: Apache-2.0
 */
 @import "../../../styles/base/all";
 
-$header-padding: 1em 1.2em;
-$header-filter-margin: 0.5em 1em 0 0;
-$header-border: 1px solid $color-mauro-dark-green;
-$header-border-radius: 4px;
-
-$request-heading-background-color: $color-mauro-dark-green;
-$request-heading-color: $color-white;
-$request-header-padding: 0.5em 1.2em;
-
 $request-elements-max-height: auto;
-$row-footer-content-color: $color-mauro-light-gold;
-$back-link-color: $color-mauro-dark-green;
 
 .mdm-my-request {
-  border: $header-border;
-  border-radius: $header-border-radius;
-
-  &__query {
-    padding: 0.5em 0.75em;
-    background-color: $row-footer-content-color;
-
-    &--row {
-      padding: 0.5em 0.75em;
-    }
-
-    &--container {
-      padding-bottom: 2px;
-    }
-
-    &--description {
-      padding: 0.5em 0.75em;
-      display: flex;
-      justify-content: space-between;
-
-      &-buttons {
-        margin-left: auto;
-
-        button {
-          width: 160px;
-        }
-      }
-    }
-  }
-
-  &__request-description {
-    padding: 0.5em 0.75em;
-    background-color: $row-footer-content-color;
-    display: flex;
-    justify-content: space-between;
-    &-container {
-      padding-bottom: 2px;
-    }
-  }
-
-  &__header {
-    padding: $header-padding;
-    border-bottom: $header-border;
-    border-radius: $header-border-radius;
-
-    h1 {
-      margin: 0;
-    }
-  }
-
-  &__filter {
-    display: inline-block;
-    margin: $header-filter-margin;
-
-    label {
-      margin-left: 0.5em;
-    }
-  }
-
   &__progress {
     margin: 0 0 1em 0;
-  }
-
-  &__list {
-    overflow-y: scroll;
-    max-height: $request-elements-max-height;
-
-    .mat-list-option {
-      height: auto;
-    }
-  }
-
-  &__request-name {
-    display: inline-block;
-    width: 120px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    vertical-align: middle;
-  }
-
-  &__request-header {
-    padding: $request-header-padding;
-    border-radius: 4px;
-    color: $request-heading-color;
-    background-color: $request-heading-background-color;
-
-    &--name {
-      margin-left: auto;
-      font-size: 16px;
-    }
-
-    &--info {
-      margin-top: 1.2em;
-    }
-
-    &--buttons {
-      button {
-        width: 160px;
-      }
-    }
-  }
-
-  &__request-header-title {
-    display: flex;
-    justify-content: space-between;
   }
 
   &__request-elements {
@@ -147,15 +32,5 @@ $back-link-color: $color-mauro-dark-green;
 
   &__request-elements-footer {
     padding: 0.75em 1.2em;
-  }
-
-  &__back-link {
-    margin: 1em 0;
-
-    a {
-      text-decoration: none;
-      font-weight: 500;
-      color: $back-link-color;
-    }
   }
 }

--- a/src/app/pages/my-requests/my-requests.component.html
+++ b/src/app/pages/my-requests/my-requests.component.html
@@ -45,33 +45,18 @@ SPDX-License-Identifier: Apache-2.0
     <p class="text-center">
       You currently have no requests. Try
       <a routerLink="/search">searching</a> or <a routerLink="/browse">browsing</a> our
-      catalogue and start creating some.
+      catalogue and start creating some. If you are still unsure what to look for, try
+      viewing our <a routerLink="/templates">request templates</a> to base your own
+      requests on.
     </p>
   </div>
   <div *ngIf="allRequests && allRequests.length > 0" class="row">
     <div *ngFor="let request of filteredRequests">
       <div class="col">
-        <div class="mdm-my-requests__request">
-          <div class="mdm-my-requests__request-header">
-            <div class="mdm-my-requests__request-header-title">
-              <div class="mdm-my-requests__request-header--name">
-                <p>{{ request.label }}</p>
-              </div>
-              <a [routerLink]="['/requests', request.id]"
-                ><button mat-raised-button>View details</button></a
-              >
-            </div>
-          </div>
-          <div class="mdm-my-requests__request-row__footer">
-            <div *ngIf="request.description">
-              <p>{{ request.description }}</p>
-            </div>
-            <div *ngIf="!request.description">
-              <p>No description provided</p>
-            </div>
-            <mdm-request-status-chip [status]="request.status"></mdm-request-status-chip>
-          </div>
-        </div>
+        <mdm-data-request-row
+          [request]="request"
+          [detailsRouterLink]="['/requests', request.id]"
+        ></mdm-data-request-row>
       </div>
     </div>
   </div>

--- a/src/app/pages/my-requests/my-requests.component.scss
+++ b/src/app/pages/my-requests/my-requests.component.scss
@@ -18,78 +18,9 @@ SPDX-License-Identifier: Apache-2.0
 */
 @import "../../../styles/base/all";
 
-$header-padding: 1em 1.2em;
 $header-filter-margin: 0.5em 1em 0 0;
-$header-border: 1px solid $color-mauro-dark-green;
-$header-border-radius: 4px;
-
-$request-heading-background-color: $color-mauro-dark-green;
-$request-heading-color: $color-white;
-$request-header-padding: 0.5em 1.2em;
-
-$request-elements-max-height: auto;
-$row-footer-content-color: $color-mauro-light-gold;
 
 .mdm-my-requests {
-  border: $header-border;
-  border-radius: $header-border-radius;
-
-  &__request {
-    padding-bottom: 28px;
-  }
-
-  &__request-row__footer {
-    padding: 0.75em 1.2em;
-    background-color: $row-footer-content-color;
-    button {
-      float: right;
-      width: 160px;
-    }
-  }
-
-  &__header {
-    padding: $header-padding;
-    border-bottom: $header-border;
-    border-radius: $header-border-radius;
-
-    h1 {
-      margin: 0;
-    }
-  }
-
-  &__request-name {
-    display: inline-block;
-    width: 120px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    vertical-align: middle;
-  }
-
-  &__request-header {
-    padding: $request-header-padding;
-    border-radius: 4px;
-    color: $request-heading-color;
-    background-color: $request-heading-background-color;
-
-    &--name {
-      font-size: 16px;
-    }
-
-    &--info {
-      margin-top: 1.2em;
-    }
-
-    button {
-      width: 160px;
-    }
-  }
-
-  &__request-header-title {
-    display: flex;
-    justify-content: space-between;
-  }
-
   &__filter {
     display: inline-block;
     margin: $header-filter-margin;

--- a/src/app/pages/my-requests/my-requests.component.spec.ts
+++ b/src/app/pages/my-requests/my-requests.component.spec.ts
@@ -107,7 +107,6 @@ describe('MyRequestsComponent', () => {
     expect(harness.component.allRequests).toStrictEqual([]);
     expect(harness.component.filteredRequests).toStrictEqual([]);
     expect(harness.component.statusFilters).toStrictEqual([]);
-    expect(harness.component.requestElements).toStrictEqual([]);
   });
 
   describe('initialisation', () => {

--- a/src/app/pages/my-requests/my-requests.component.ts
+++ b/src/app/pages/my-requests/my-requests.component.ts
@@ -21,7 +21,6 @@ import { MatCheckboxChange } from '@angular/material/checkbox';
 import { ToastrService } from 'ngx-toastr';
 import { catchError, EMPTY, finalize, throwError } from 'rxjs';
 import {
-  DataElementSearchResult,
   DataRequest,
   DataRequestStatus,
 } from 'src/app/data-explorer/data-explorer.types';
@@ -37,9 +36,7 @@ export class MyRequestsComponent implements OnInit {
   allRequests: DataRequest[] = [];
   filteredRequests: DataRequest[] = [];
   statusFilters: DataRequestStatus[] = [];
-  requestElements: DataElementSearchResult[] = [];
   state: 'idle' | 'loading' = 'idle';
-  creatingNextVersion = false;
 
   constructor(
     private security: SecurityService,
@@ -66,10 +63,6 @@ export class MyRequestsComponent implements OnInit {
     }
 
     this.filterRequests();
-  }
-
-  refreshRequests() {
-    this.initialiseRequests();
   }
 
   initialiseRequests() {
@@ -104,6 +97,4 @@ export class MyRequestsComponent implements OnInit {
 
     this.state = 'idle';
   }
-
-
 }

--- a/src/app/pages/pages.module.ts
+++ b/src/app/pages/pages.module.ts
@@ -45,6 +45,8 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { ChangePasswordComponent } from './change-password/change-password.component';
 import { RequestQueryComponent } from './request-query/request-query.component';
 import { MyRequestDetailComponent } from './my-request-detail/my-request-detail.component';
+import { TemplateRequestsComponent } from './template-requests/template-requests.component';
+import { TemplateRequestDetailComponent } from './template-request-detail/template-request-detail.component';
 
 @NgModule({
   declarations: [
@@ -70,6 +72,8 @@ import { MyRequestDetailComponent } from './my-request-detail/my-request-detail.
     ChangePasswordComponent,
     RequestQueryComponent,
     MyRequestDetailComponent,
+    TemplateRequestsComponent,
+    TemplateRequestDetailComponent,
   ],
   imports: [
     CoreModule,

--- a/src/app/pages/pages.routes.ts
+++ b/src/app/pages/pages.routes.ts
@@ -39,6 +39,8 @@ import { ChangePasswordComponent } from './change-password/change-password.compo
 import { RequestQueryComponent } from './request-query/request-query.component';
 import { ModelPageDirtyGuard } from '../shared/guards/model-page-dirty.guard';
 import { MyRequestDetailComponent } from './my-request-detail/my-request-detail.component';
+import { TemplateRequestsComponent } from './template-requests/template-requests.component';
+import { TemplateRequestDetailComponent } from './template-request-detail/template-request-detail.component';
 
 export const buildStaticContentRoute = (path: string, staticAssetPath: string): Route => {
   return {
@@ -168,6 +170,16 @@ export const routes: Route[] = [
   {
     path: 'requests/:requestId',
     component: MyRequestDetailComponent,
+    canActivate: [AuthorizedGuard],
+  },
+  {
+    path: 'templates',
+    component: TemplateRequestsComponent,
+    canActivate: [AuthorizedGuard],
+  },
+  {
+    path: 'templates/:requestId',
+    component: TemplateRequestDetailComponent,
     canActivate: [AuthorizedGuard],
   },
 ];

--- a/src/app/pages/search-listing/search-listing.component.html
+++ b/src/app/pages/search-listing/search-listing.component.html
@@ -17,12 +17,11 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <div *ngIf="source !== 'unknown'" class="container hero-top-spacer">
-  <div class="mdm-search-listing__back-link">
-    <a [routerLink]="backRouterLink" [queryParams]="backQueryParams">
-      <span class="fa-solid fa-arrow-left"></span>
-      {{ backLabel }}
-    </a>
-  </div>
+  <mdm-back-link
+    [routerLink]="backRouterLink"
+    [queryParams]="backQueryParams"
+    [label]="backLabel"
+  ></mdm-back-link>
   <div class="mdm-search-listing__search">
     <form role="form" name="search" (submit)="updateSearch()">
       <mat-form-field appearance="outline" class="mdm-search-listing__search-input">

--- a/src/app/pages/search-listing/search-listing.component.scss
+++ b/src/app/pages/search-listing/search-listing.component.scss
@@ -19,15 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 
 @import "../../../styles/base/all";
 
-$back-link-color: $color-mauro-dark-green;
-
 $no-results-background-color: $color-mauro-light-gold;
 
 .mdm-search-listing {
-  &__back-link {
-    margin: 1em 0;
-  }
-
   &__search {
     text-align: center;
   }
@@ -40,14 +34,6 @@ $no-results-background-color: $color-mauro-light-gold;
     .vertically-aligned {
       display: flex;
       align-items: center;
-    }
-  }
-
-  &__back-link {
-    a {
-      text-decoration: none;
-      font-weight: 500;
-      color: $back-link-color;
     }
   }
 

--- a/src/app/pages/template-request-detail/template-request-detail.component.html
+++ b/src/app/pages/template-request-detail/template-request-detail.component.html
@@ -1,0 +1,66 @@
+<!--
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+<div class="container">
+  <div *ngIf="request">
+    <div class="main-row hero">
+      <h1>{{ request.label }}</h1>
+    </div>
+    <mdm-back-link routerLink="/templates" label="Back to Templates"></mdm-back-link>
+    <div *ngIf="state === 'loading'" class="mdm-template-request-detail__progress">
+      <mat-progress-bar color="primary" mode="indeterminate"></mat-progress-bar>
+    </div>
+    <div class="col">
+      <mdm-data-request-row
+        [request]="request"
+        [showLabel]="false"
+        [showStatus]="false"
+        [showCopyButton]="true"
+        (copyClick)="copy()"
+      ></mdm-data-request-row>
+    </div>
+
+    <h2>Queries</h2>
+
+    <mdm-data-query-row
+      queryType="cohort"
+      [condition]="cohortQuery"
+      [readOnly]="true"
+    ></mdm-data-query-row>
+    <mdm-data-query-row
+      queryType="data"
+      [condition]="dataQuery"
+      [readOnly]="true"
+    ></mdm-data-query-row>
+
+    <h2>Data elements</h2>
+
+    <div
+      class="mdm-my-request__request-elements"
+      *ngIf="requestElements && requestElements.length > 0"
+    >
+      <mdm-data-element-row
+        *ngFor="let element of requestElements"
+        [item]="element"
+        [canDelete]="false"
+        [suppressViewRequestsDialogButton]="true"
+      >
+      </mdm-data-element-row>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/template-request-detail/template-request-detail.component.scss
+++ b/src/app/pages/template-request-detail/template-request-detail.component.scss
@@ -1,0 +1,18 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/

--- a/src/app/pages/template-request-detail/template-request-detail.component.spec.ts
+++ b/src/app/pages/template-request-detail/template-request-detail.component.spec.ts
@@ -1,0 +1,214 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { ActivatedRoute } from '@angular/router';
+import {
+  CatalogueItemDomainType,
+  DataElement,
+  FolderDetail,
+} from '@maurodatamapper/mdm-resources';
+import { ToastrService } from 'ngx-toastr';
+import { of, throwError } from 'rxjs';
+import {
+  DataElementSearchResult,
+  DataRequest,
+  DataRequestQueryPayload,
+} from 'src/app/data-explorer/data-explorer.types';
+import { DataRequestsService } from 'src/app/data-explorer/data-requests.service';
+import { createDataRequestsServiceStub } from 'src/app/testing/stubs/data-requests.stub';
+import { createToastrServiceStub } from 'src/app/testing/stubs/toastr.stub';
+import {
+  ComponentHarness,
+  setupTestModuleForComponent,
+} from 'src/app/testing/testing.helpers';
+
+import { TemplateRequestDetailComponent } from './template-request-detail.component';
+
+describe('TemplateRequestDetailComponent', () => {
+  let harness: ComponentHarness<TemplateRequestDetailComponent>;
+
+  const dataRequestsStub = createDataRequestsServiceStub();
+  const toastrStub = createToastrServiceStub();
+
+  const templateId = '123';
+  const activatedRoute: ActivatedRoute = {
+    params: of({
+      requestId: templateId,
+    }),
+  } as unknown as ActivatedRoute;
+
+  beforeEach(async () => {
+    harness = await setupTestModuleForComponent(TemplateRequestDetailComponent, {
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: activatedRoute,
+        },
+        {
+          provide: DataRequestsService,
+          useValue: dataRequestsStub,
+        },
+        {
+          provide: ToastrService,
+          useValue: toastrStub,
+        },
+      ],
+    });
+  });
+
+  it('should create', () => {
+    expect(harness.isComponentCreated).toBeTruthy();
+    expect(harness.component.request).toBeUndefined();
+    expect(harness.component.requestElements).toStrictEqual([]);
+    expect(harness.component.cohortQuery.rules).toStrictEqual([]);
+    expect(harness.component.dataQuery.rules).toStrictEqual([]);
+    expect(harness.component.state).toBe('idle');
+  });
+
+  describe('initialisation', () => {
+    const template: DataRequest = {
+      id: templateId,
+      label: 'template',
+      domainType: CatalogueItemDomainType.DataModel,
+      status: 'submitted',
+    };
+
+    it('should load a template', () => {
+      dataRequestsStub.get.mockImplementationOnce((id) => {
+        expect(id).toBe(templateId);
+        expect(harness.component.state).toBe('loading');
+        return of(template);
+      });
+
+      harness.component.ngOnInit();
+
+      expect(harness.component.request).toBe(template);
+      expect(harness.component.state).toBe('idle');
+    });
+
+    it('should display an error if failed to load template', () => {
+      const toastrSpy = jest.spyOn(toastrStub, 'error');
+
+      dataRequestsStub.get.mockImplementationOnce(() =>
+        throwError(() => new Error('get template failed'))
+      );
+
+      harness.component.ngOnInit();
+
+      expect(harness.component.state).toBe('idle');
+      expect(toastrSpy).toHaveBeenCalled();
+      expect(harness.component.request).toBeUndefined();
+    });
+
+    it('should load template data elements and queries', () => {
+      const elements: DataElement[] = [
+        {
+          id: '1',
+          domainType: CatalogueItemDomainType.DataElement,
+          label: 'element 1',
+        },
+        {
+          id: '2',
+          domainType: CatalogueItemDomainType.DataElement,
+          label: 'element 2',
+        },
+      ];
+
+      const cohortQueryPayload: Required<DataRequestQueryPayload> = {
+        ruleId: '1',
+        representationId: '2',
+        type: 'cohort',
+        condition: { rules: [], condition: 'and' },
+      };
+
+      const dataQueryPayload: Required<DataRequestQueryPayload> = {
+        ruleId: '1',
+        representationId: '3',
+        type: 'data',
+        condition: { rules: [], condition: 'and' },
+      };
+
+      dataRequestsStub.get.mockImplementationOnce(() => of(template));
+
+      dataRequestsStub.listDataElements.mockImplementationOnce((req) => {
+        expect(req).toBe(template);
+        expect(harness.component.state).toBe('loading');
+        return of(elements);
+      });
+
+      dataRequestsStub.getQuery.mockImplementationOnce(() => of(cohortQueryPayload));
+      dataRequestsStub.getQuery.mockImplementationOnce(() => of(dataQueryPayload));
+
+      harness.component.ngOnInit();
+
+      const expectedElements = elements.map((element) => {
+        return (
+          element
+            ? {
+                ...element,
+                isSelected: false,
+                isBookmarked: false,
+              }
+            : null
+        ) as DataElementSearchResult;
+      });
+
+      expect(harness.component.requestElements).toStrictEqual(expectedElements);
+      expect(harness.component.state).toBe('idle');
+    });
+  });
+
+  describe('copy request', () => {
+    const request: DataRequest = {
+      id: '1',
+      domainType: CatalogueItemDomainType.DataModel,
+      label: 'template 1',
+      status: 'submitted',
+    };
+
+    const requestFolder: FolderDetail = {
+      id: '2',
+      domainType: CatalogueItemDomainType.Folder,
+      label: 'my requests',
+      availableActions: [],
+    };
+
+    beforeEach(() => {
+      dataRequestsStub.getRequestsFolder.mockImplementationOnce(() => of(requestFolder));
+      dataRequestsStub.forkWithDialogs.mockClear();
+    });
+
+    it('should copy a template to a new request', () => {
+      dataRequestsStub.forkWithDialogs.mockImplementationOnce((req, options) => {
+        expect(req).toBe(request);
+        expect(options?.targetFolder).toBe(requestFolder);
+        return of({
+          ...request,
+          id: '3',
+          label: 'copied request',
+          status: 'unsent',
+        });
+      });
+
+      harness.component.request = request;
+      harness.component.copy();
+
+      expect(dataRequestsStub.forkWithDialogs).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/pages/template-request-detail/template-request-detail.component.ts
+++ b/src/app/pages/template-request-detail/template-request-detail.component.ts
@@ -1,0 +1,131 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { DataElement } from '@maurodatamapper/mdm-resources';
+import { ToastrService } from 'ngx-toastr';
+import { catchError, EMPTY, forkJoin, switchMap } from 'rxjs';
+import {
+  DataElementSearchResult,
+  DataRequest,
+  QueryCondition,
+} from 'src/app/data-explorer/data-explorer.types';
+import { DataRequestsService } from 'src/app/data-explorer/data-requests.service';
+
+@Component({
+  selector: 'mdm-template-request-detail',
+  templateUrl: './template-request-detail.component.html',
+  styleUrls: ['./template-request-detail.component.scss'],
+})
+export class TemplateRequestDetailComponent implements OnInit {
+  request?: DataRequest;
+  requestElements: DataElementSearchResult[] = [];
+  cohortQuery: QueryCondition = {
+    condition: 'and',
+    rules: [],
+  };
+  dataQuery: QueryCondition = {
+    condition: 'and',
+    rules: [],
+  };
+  state: 'idle' | 'loading' = 'idle';
+
+  constructor(
+    private route: ActivatedRoute,
+    private dataRequests: DataRequestsService,
+    private toastr: ToastrService
+  ) {}
+
+  ngOnInit(): void {
+    this.route.params
+      .pipe(
+        switchMap((params) => {
+          const requestId = params.requestId as string;
+          this.state = 'loading';
+          return this.dataRequests.get(requestId);
+        }),
+        catchError((error) => {
+          this.toastr.error(`Invalid Request Id. ${error}`);
+          this.state = 'idle';
+          return EMPTY;
+        }),
+        switchMap((request) => {
+          if (!request?.id) {
+            return EMPTY;
+          }
+
+          this.request = request;
+
+          return forkJoin([
+            this.dataRequests.listDataElements(request),
+            this.dataRequests.getQuery(request.id, 'cohort'),
+            this.dataRequests.getQuery(request.id, 'data'),
+          ]);
+        }),
+        catchError(() => {
+          this.toastr.error('There was a problem locating the template details.');
+          this.state = 'idle';
+          return EMPTY;
+        })
+      )
+      .subscribe(([dataElements, cohortQuery, dataQuery]) => {
+        this.state = 'idle';
+        this.requestElements = this.mapDataElements(dataElements);
+
+        if (cohortQuery) {
+          this.cohortQuery = cohortQuery.condition;
+        }
+
+        if (dataQuery) {
+          this.dataQuery = dataQuery.condition;
+        }
+      });
+  }
+
+  copy() {
+    this.dataRequests
+      .getRequestsFolder()
+      .pipe(
+        switchMap((requestFolder) => {
+          if (!this.request) {
+            return EMPTY;
+          }
+
+          return this.dataRequests.forkWithDialogs(this.request, {
+            targetFolder: requestFolder,
+          });
+        })
+      )
+      .subscribe();
+  }
+
+  private mapDataElements(dataElements: DataElement[]) {
+    return dataElements.map((element) => {
+      return (
+        element
+          ? {
+              ...element,
+              isSelected: false,
+              isBookmarked: false,
+            }
+          : null
+      ) as DataElementSearchResult;
+    });
+  }
+}

--- a/src/app/pages/template-requests/template-requests.component.html
+++ b/src/app/pages/template-requests/template-requests.component.html
@@ -1,0 +1,57 @@
+<!--
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+<div class="container">
+  <div class="main-row hero">
+    <h1>Templates</h1>
+    <div *ngIf="templateRequests && templateRequests.length > 0">
+      <p>
+        Searching our large catalogue for all the data you require can be daunting.
+        Fortunately, we have collected together some typical types of research data
+        request so they can be reused. Browse our selection of predefined request
+        templates as a starting point for collating your research data requests. Any
+        requests that you copy from here can be modified to suit your needs as you go
+        before formal submission.
+      </p>
+    </div>
+  </div>
+  <div *ngIf="state === 'loading'" class="mdm-template-requests__progress">
+    <mat-progress-bar color="primary" mode="indeterminate"></mat-progress-bar>
+  </div>
+  <div *ngIf="!templateRequests || templateRequests.length === 0" class="row">
+    <p class="text-center">
+      We currently have no data request templates but are working on adding some soon. In
+      the meantime, you are able to
+      <a routerLink="/search">search</a> or <a routerLink="/browse">browse</a> our
+      catalogue and start creating your own research data requests from scratch.
+    </p>
+  </div>
+  <div *ngIf="templateRequests && templateRequests.length > 0" class="row">
+    <div *ngFor="let request of templateRequests">
+      <div class="col">
+        <mdm-data-request-row
+          [request]="request"
+          [showStatus]="false"
+          [detailsRouterLink]="['/templates', request.id]"
+          [showCopyButton]="true"
+          (copyClick)="copy(request)"
+        ></mdm-data-request-row>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/template-requests/template-requests.component.scss
+++ b/src/app/pages/template-requests/template-requests.component.scss
@@ -1,0 +1,18 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/

--- a/src/app/pages/template-requests/template-requests.component.spec.ts
+++ b/src/app/pages/template-requests/template-requests.component.spec.ts
@@ -1,0 +1,134 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { CatalogueItemDomainType, FolderDetail } from '@maurodatamapper/mdm-resources';
+import { ToastrService } from 'ngx-toastr';
+import { of, throwError } from 'rxjs';
+import { DataRequest } from 'src/app/data-explorer/data-explorer.types';
+import { DataRequestsService } from 'src/app/data-explorer/data-requests.service';
+import { createDataRequestsServiceStub } from 'src/app/testing/stubs/data-requests.stub';
+import { createToastrServiceStub } from 'src/app/testing/stubs/toastr.stub';
+import {
+  ComponentHarness,
+  setupTestModuleForComponent,
+} from 'src/app/testing/testing.helpers';
+
+import { TemplateRequestsComponent } from './template-requests.component';
+
+describe('TemplateRequestsComponent', () => {
+  let harness: ComponentHarness<TemplateRequestsComponent>;
+
+  const dataRequestsStub = createDataRequestsServiceStub();
+  const toastrStub = createToastrServiceStub();
+
+  beforeEach(async () => {
+    harness = await setupTestModuleForComponent(TemplateRequestsComponent, {
+      providers: [
+        {
+          provide: DataRequestsService,
+          useValue: dataRequestsStub,
+        },
+        {
+          provide: ToastrService,
+          useValue: toastrStub,
+        },
+      ],
+    });
+  });
+
+  it('should create', () => {
+    expect(harness.isComponentCreated).toBeTruthy();
+    expect(harness.component.templateRequests).toStrictEqual([]);
+    expect(harness.component.state).toBe('idle');
+  });
+
+  describe('initialisation', () => {
+    it('should list all templates', () => {
+      const templates: DataRequest[] = [
+        {
+          id: '1',
+          domainType: CatalogueItemDomainType.DataModel,
+          label: 'template 1',
+          status: 'submitted',
+        },
+        {
+          id: '2',
+          domainType: CatalogueItemDomainType.DataModel,
+          label: 'template 2',
+          status: 'submitted',
+        },
+      ];
+
+      dataRequestsStub.listTemplates.mockImplementationOnce(() => of(templates));
+
+      harness.component.ngOnInit();
+
+      expect(harness.component.templateRequests).toStrictEqual(templates);
+    });
+
+    it('it should raise error if failed to get templates', () => {
+      const toastrSpy = jest.spyOn(toastrStub, 'error');
+
+      dataRequestsStub.listTemplates.mockImplementationOnce(() =>
+        throwError(() => new Error('list templates failed'))
+      );
+
+      harness.component.ngOnInit();
+
+      expect(toastrSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('copy request', () => {
+    const request: DataRequest = {
+      id: '1',
+      domainType: CatalogueItemDomainType.DataModel,
+      label: 'template 1',
+      status: 'submitted',
+    };
+
+    const requestFolder: FolderDetail = {
+      id: '2',
+      domainType: CatalogueItemDomainType.Folder,
+      label: 'my requests',
+      availableActions: [],
+    };
+
+    beforeEach(() => {
+      dataRequestsStub.getRequestsFolder.mockImplementationOnce(() => of(requestFolder));
+      dataRequestsStub.forkWithDialogs.mockClear();
+    });
+
+    it('should copy a template to a new request', () => {
+      dataRequestsStub.forkWithDialogs.mockImplementationOnce((req, options) => {
+        expect(req).toBe(request);
+        expect(options?.targetFolder).toBe(requestFolder);
+        return of({
+          ...request,
+          id: '3',
+          label: 'copied request',
+          status: 'unsent',
+        });
+      });
+
+      harness.component.copy(request);
+
+      expect(dataRequestsStub.forkWithDialogs).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/pages/template-requests/template-requests.component.ts
+++ b/src/app/pages/template-requests/template-requests.component.ts
@@ -1,0 +1,65 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Component, OnInit } from '@angular/core';
+import { ToastrService } from 'ngx-toastr';
+import { catchError, EMPTY, finalize, switchMap } from 'rxjs';
+import { DataRequest } from 'src/app/data-explorer/data-explorer.types';
+import { DataRequestsService } from 'src/app/data-explorer/data-requests.service';
+
+@Component({
+  selector: 'mdm-template-requests',
+  templateUrl: './template-requests.component.html',
+  styleUrls: ['./template-requests.component.scss'],
+})
+export class TemplateRequestsComponent implements OnInit {
+  templateRequests: DataRequest[] = [];
+  state: 'idle' | 'loading' = 'idle';
+
+  constructor(private dataRequests: DataRequestsService, private toastr: ToastrService) {}
+
+  ngOnInit(): void {
+    this.state = 'loading';
+
+    this.dataRequests
+      .listTemplates()
+      .pipe(
+        catchError(() => {
+          this.toastr.error('There was a problem finding the templates.');
+          return EMPTY;
+        }),
+        finalize(() => (this.state = 'idle'))
+      )
+      .subscribe((templateRequests) => {
+        this.templateRequests = templateRequests;
+      });
+  }
+
+  copy(request: DataRequest) {
+    this.dataRequests
+      .getRequestsFolder()
+      .pipe(
+        switchMap((requestFolder) =>
+          this.dataRequests.forkWithDialogs(request, {
+            targetFolder: requestFolder,
+          })
+        )
+      )
+      .subscribe();
+  }
+}

--- a/src/app/shared/back-link/back-link.component.html
+++ b/src/app/shared/back-link/back-link.component.html
@@ -1,0 +1,24 @@
+<!--
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+<div *ngIf="routerLink && label" class="back-link">
+  <a [routerLink]="routerLink" [queryParams]="queryParams">
+    <span class="fa-solid fa-arrow-left"></span>
+    {{ label }}
+  </a>
+</div>

--- a/src/app/shared/back-link/back-link.component.scss
+++ b/src/app/shared/back-link/back-link.component.scss
@@ -1,0 +1,31 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+@import "../../../styles/base/all";
+
+$back-link-color: $color-mauro-dark-green;
+
+.back-link {
+  margin: 1em 0;
+
+  a {
+    text-decoration: none;
+    font-weight: 500;
+    color: $back-link-color;
+  }
+}

--- a/src/app/shared/back-link/back-link.component.spec.ts
+++ b/src/app/shared/back-link/back-link.component.spec.ts
@@ -1,0 +1,36 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import {
+  ComponentHarness,
+  setupTestModuleForComponent,
+} from 'src/app/testing/testing.helpers';
+
+import { BackLinkComponent } from './back-link.component';
+
+describe('BackLinkComponent', () => {
+  let harness: ComponentHarness<BackLinkComponent>;
+
+  beforeEach(async () => {
+    harness = await setupTestModuleForComponent(BackLinkComponent);
+  });
+
+  it('should create', () => {
+    expect(harness.isComponentCreated).toBeTruthy();
+  });
+});

--- a/src/app/shared/back-link/back-link.component.ts
+++ b/src/app/shared/back-link/back-link.component.ts
@@ -1,0 +1,32 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Component, Input } from '@angular/core';
+import { Params } from '@angular/router';
+import { RouterLinkRef } from '../types/shared.types';
+
+@Component({
+  selector: 'mdm-back-link',
+  templateUrl: './back-link.component.html',
+  styleUrls: ['./back-link.component.scss'],
+})
+export class BackLinkComponent {
+  @Input() label?: string;
+  @Input() routerLink?: RouterLinkRef;
+  @Input() queryParams?: Params | null;
+}

--- a/src/app/shared/header-and-content-box/header-and-content-box.component.html
+++ b/src/app/shared/header-and-content-box/header-and-content-box.component.html
@@ -1,0 +1,32 @@
+<!--
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+<div class="mdm-header-and-content-box">
+  <div class="mdm-header-and-content-box__header">
+    <div class="mdm-header-and-content-box__header-title">
+      <ng-content select="[header-title]"></ng-content>
+    </div>
+    <div class="mdm-header-and-content-box__header-actions">
+      <ng-content select="[header-actions]"></ng-content>
+    </div>
+  </div>
+  <div class="mdm-header-and-content-box__content">
+    <!-- Main content -->
+    <ng-content></ng-content>
+  </div>
+</div>

--- a/src/app/shared/header-and-content-box/header-and-content-box.component.scss
+++ b/src/app/shared/header-and-content-box/header-and-content-box.component.scss
@@ -1,0 +1,48 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+@import "../../../styles/base/all";
+
+$header-padding: 0.5em 1.2em;
+$header-border-radius: 4px;
+$header-background-color: $color-mauro-dark-green;
+$header-color: $color-white;
+
+$content-padding: 0.75em 1.2em;
+$content-background-color: $color-mauro-light-gold;
+
+.mdm-header-and-content-box {
+  margin-bottom: 28px;
+
+  &__header {
+    padding: $header-padding;
+    border-radius: $header-border-radius;
+    color: $header-color;
+    background-color: $header-background-color;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  &__content {
+    padding: $content-padding;
+    background-color: $content-background-color;
+    display: flex;
+    justify-content: space-between;
+  }
+}

--- a/src/app/shared/header-and-content-box/header-and-content-box.component.spec.ts
+++ b/src/app/shared/header-and-content-box/header-and-content-box.component.spec.ts
@@ -1,0 +1,36 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import {
+  ComponentHarness,
+  setupTestModuleForComponent,
+} from 'src/app/testing/testing.helpers';
+
+import { HeaderAndContentBoxComponent } from './header-and-content-box.component';
+
+describe('HeaderAndContentBoxComponent', () => {
+  let harness: ComponentHarness<HeaderAndContentBoxComponent>;
+
+  beforeEach(async () => {
+    harness = await setupTestModuleForComponent(HeaderAndContentBoxComponent);
+  });
+
+  it('should create', () => {
+    expect(harness.isComponentCreated).toBeTruthy();
+  });
+});

--- a/src/app/shared/header-and-content-box/header-and-content-box.component.ts
+++ b/src/app/shared/header-and-content-box/header-and-content-box.component.ts
@@ -1,0 +1,26 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'mdm-header-and-content-box',
+  templateUrl: './header-and-content-box.component.html',
+  styleUrls: ['./header-and-content-box.component.scss'],
+})
+export class HeaderAndContentBoxComponent {}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -35,6 +35,8 @@ import { DataElementInRequestComponent } from './data-element-in-request/data-el
 import { DataElementMultiSelectComponent } from './data-element-multi-select/data-element-multi-select.component';
 import { ConfirmationDialogComponent } from './confirmation-dialog/confirmation-dialog.component';
 import { AutocompleteSelectComponent } from './autocomplete-select/autocomplete-select.component';
+import { BackLinkComponent } from './back-link/back-link.component';
+import { HeaderAndContentBoxComponent } from './header-and-content-box/header-and-content-box.component';
 
 @NgModule({
   declarations: [
@@ -54,6 +56,8 @@ import { AutocompleteSelectComponent } from './autocomplete-select/autocomplete-
     DataElementMultiSelectComponent,
     ConfirmationDialogComponent,
     AutocompleteSelectComponent,
+    BackLinkComponent,
+    HeaderAndContentBoxComponent,
   ],
   imports: [CoreModule, NgChartsModule],
   exports: [
@@ -71,6 +75,8 @@ import { AutocompleteSelectComponent } from './autocomplete-select/autocomplete-
     DataElementInRequestComponent,
     DataElementMultiSelectComponent,
     AutocompleteSelectComponent,
+    BackLinkComponent,
+    HeaderAndContentBoxComponent,
   ],
 })
 export class SharedModule {}

--- a/src/app/shared/types/shared.types.ts
+++ b/src/app/shared/types/shared.types.ts
@@ -29,3 +29,8 @@ export interface IModelPage {
    */
   isDirty(): boolean;
 }
+
+/**
+ * Alias for Angular Router link information
+ */
+export type RouterLinkRef = any[] | string | null | undefined;

--- a/src/app/testing/stubs/data-model.stub.ts
+++ b/src/app/testing/stubs/data-model.stub.ts
@@ -108,6 +108,9 @@ export interface DataModelServiceStub {
   createFork: jest.MockedFunction<DataModelForkFn>;
   elementsInAnotherModel: jest.MockedFunction<DataModelElementsInAnotherModelFn>;
   dataElementToBasic: jest.MockedFunction<DataModelDataElementToBasicFn>;
+  moveToFolder: jest.MockedFunction<
+    (modelId: Uuid, targetFolderId: Uuid) => Observable<DataModelDetail>
+  >;
 }
 
 export const createDataModelServiceStub = (): DataModelServiceStub => {
@@ -133,5 +136,6 @@ export const createDataModelServiceStub = (): DataModelServiceStub => {
     elementsInAnotherModel:
       jest.fn() as jest.MockedFunction<DataModelElementsInAnotherModelFn>,
     dataElementToBasic: jest.fn() as jest.MockedFunction<DataModelDataElementToBasicFn>,
+    moveToFolder: jest.fn(),
   };
 };

--- a/src/app/testing/stubs/data-requests.stub.ts
+++ b/src/app/testing/stubs/data-requests.stub.ts
@@ -32,6 +32,7 @@ import {
   DataRequestQuery,
   DataRequestQueryPayload,
   DataRequestQueryType,
+  ForkDataRequestOptions,
 } from 'src/app/data-explorer/data-explorer.types';
 import { DataAccessRequestsSourceTargetIntersections } from 'src/app/data-explorer/data-requests.service';
 import { RequestCreatedAction } from 'src/app/data-explorer/request-created-dialog/request-created-dialog.component';
@@ -79,9 +80,13 @@ export type DeleteDataElementsFromQueryFn = (
 export interface DataRequestsServiceStub {
   get: jest.MockedFunction<(id: Uuid) => Observable<DataRequest>>;
   list: jest.MockedFunction<DataRequestsListFn>;
+  listTemplates: jest.MockedFunction<() => Observable<DataRequest[]>>;
   listDataElements: jest.MockedFunction<DataRequestsListElementsFn>;
   createFromDataElements: jest.MockedFunction<DataRequestsCreateFromDataElementsFn>;
   createWithDialogs: jest.MockedFunction<CreateFromDialogsFn>;
+  forkWithDialogs: jest.MockedFunction<
+    (request: DataRequest, options?: ForkDataRequestOptions) => Observable<DataRequest>
+  >;
   getRequestsIntersections: jest.MockedFunction<DataAccessRequestsSourceTargetIntersectionsFn>;
   deleteDataElementMultiple: jest.MockedFunction<DeleteDataElementMultipleFn>;
   updateRequestsFolder: jest.MockedFunction<DataRequestsUpdateRequestsFolderFn>;
@@ -100,10 +105,12 @@ export const createDataRequestsServiceStub = (): DataRequestsServiceStub => {
   return {
     get: jest.fn(),
     list: jest.fn() as jest.MockedFunction<DataRequestsListFn>,
+    listTemplates: jest.fn(),
     listDataElements: jest.fn() as jest.MockedFunction<DataRequestsListElementsFn>,
     createFromDataElements:
       jest.fn() as jest.MockedFunction<DataRequestsCreateFromDataElementsFn>,
     createWithDialogs: jest.fn() as jest.MockedFunction<CreateFromDialogsFn>,
+    forkWithDialogs: jest.fn(),
     getRequestsIntersections:
       jest.fn() as jest.MockedFunction<DataAccessRequestsSourceTargetIntersectionsFn>,
     deleteDataElementMultiple:

--- a/src/app/testing/stubs/mdm-resources/data-model-resource.stub.ts
+++ b/src/app/testing/stubs/mdm-resources/data-model-resource.stub.ts
@@ -75,6 +75,9 @@ export interface MdmDataModelResourcesStub {
   copySubset: jest.MockedFunction<DataModelCopySubsetFn>;
   newBranchModelVersion: jest.MockedFunction<DataModelBranchVersionFn>;
   newForkModel: jest.MockedFunction<DataModelForkVersionFn>;
+  moveDataModelToFolder: jest.MockedFunction<
+    (modelId: Uuid, folderId: Uuid) => Observable<DataModelDetail>
+  >;
 }
 
 export const createDataModelStub = (): MdmDataModelResourcesStub => {
@@ -87,5 +90,6 @@ export const createDataModelStub = (): MdmDataModelResourcesStub => {
     copySubset: jest.fn() as jest.MockedFunction<DataModelCopySubsetFn>,
     newBranchModelVersion: jest.fn() as jest.MockedFunction<DataModelBranchVersionFn>,
     newForkModel: jest.fn() as jest.MockedFunction<DataModelForkVersionFn>,
+    moveDataModelToFolder: jest.fn(),
   };
 };

--- a/src/app/testing/stubs/mdm-resources/plugin-research-resource.stub.ts
+++ b/src/app/testing/stubs/mdm-resources/plugin-research-resource.stub.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { MdmResponse, Uuid } from '@maurodatamapper/mdm-resources';
+import { FolderDetail, MdmResponse, Uuid } from '@maurodatamapper/mdm-resources';
 import { Observable } from 'rxjs';
 import {
   PluginResearchContactPayload,
@@ -33,6 +33,7 @@ export interface MdmPluginResearchResourceStub {
   contact: jest.MockedFunction<PluginResearchContactFn>;
   submitRequest: jest.MockedFunction<PluginResearchSubmitRequestFn>;
   userFolder: jest.MockedFunction<PluginResearchUserFolderFn>;
+  templateFolder: jest.MockedFunction<() => Observable<FolderDetail>>;
 }
 
 export const createPluginResearchStub = (): MdmPluginResearchResourceStub => {
@@ -40,5 +41,6 @@ export const createPluginResearchStub = (): MdmPluginResearchResourceStub => {
     contact: jest.fn() as jest.MockedFunction<PluginResearchContactFn>,
     submitRequest: jest.fn() as jest.MockedFunction<PluginResearchSubmitRequestFn>,
     userFolder: jest.fn() as jest.MockedFunction<PluginResearchUserFolderFn>,
+    templateFolder: jest.fn(),
   };
 };

--- a/src/app/testing/stubs/research-plugin.stub.ts
+++ b/src/app/testing/stubs/research-plugin.stub.ts
@@ -30,6 +30,7 @@ export interface ResearchPluginServiceStub {
   contact: jest.MockedFunction<ResearchPluginContactFn>;
   submitRequest: jest.MockedFunction<ResearchPluginSubmitRequestFn>;
   userFolder: jest.MockedFunction<ResearchPluginUserFolderFn>;
+  templateFolder: jest.MockedFunction<() => Observable<FolderDetail>>;
 }
 
 export const createResearchPluginServiceStub = (): ResearchPluginServiceStub => {
@@ -37,5 +38,6 @@ export const createResearchPluginServiceStub = (): ResearchPluginServiceStub => 
     contact: jest.fn() as jest.MockedFunction<ResearchPluginContactFn>,
     submitRequest: jest.fn() as jest.MockedFunction<ResearchPluginSubmitRequestFn>,
     userFolder: jest.fn() as jest.MockedFunction<ResearchPluginUserFolderFn>,
+    templateFolder: jest.fn(),
   };
 };

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -30,6 +30,7 @@ Import more theme SASS files here to make them available to the app
 
 @import "styles/base/all";
 @import "styles/resets";
+@import "styles/app";
 @import "styles/layout";
 @import "styles/icons";
 @import "styles/forms";

--- a/src/styles/_app.scss
+++ b/src/styles/_app.scss
@@ -1,0 +1,42 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+@import "./base/all";
+
+$header-color: $color-white;
+
+h3.header-title {
+  margin: 0;
+  font-weight: 500;
+
+  a {
+    color: $header-color;
+  }
+}
+
+button.mat-icon-button {
+  span.mat-button-wrapper {
+    span.fa-solid {
+      font-size: 20px;
+    }
+  }
+}
+
+.mat-checkbox-inner-container {
+  background-color: $color-white;
+}

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -215,3 +215,7 @@ Highlights a box area behind other page components, e.g. a form
     margin: 1em;
   }
 }
+
+.full-width {
+  width: 100%;
+}


### PR DESCRIPTION
**Note:** this PR depends on MauroDataMapper-Plugins/mdm-plugin-explorer#14

Uses configuration from `mdm-plugin-explorer` to list any pre-made requests from a Mauro root folder and fork (copy) them as new user data requests.

- New top-level navigation "Templates" link, index and detail pages created
- Creation of shared, common components to make Template and My Request pages consistent
- New mdm-header-and-content-box component to simplify layout of dark green header (and action bar) with lighter content
- Make the label of a template/request row a clickable link to go to the detail page
- Refactor My Requests pages to re-use code and make constsient
- Make similar changes to the mdm-data-element-search-result component for consistency
- Add help content in pages to direct users to templates page
- Update documentation in /docs folder

Resolves #203 

# Testing

If you don't want to wait for MauroDataMapper-Plugins/mdm-plugin-explorer#14 to be merged, it is possible to test this PR locally:

1. Fetch and checkout the branch for MauroDataMapper-Plugins/mdm-plugin-explorer#14.
2. Build the plugin manually using `gradle publishToMavenLocal` to build your own local plugin snapshot
3. Use `mdm-application-build` and include a reference to `mdm-plugin-explorer` snapshot, this should pick up your local build copy
4. When running the backend, the plugin should now have bootstrapped a new folder called "Mauro Explorer Templates"
5. In MDE, create some data requests and submit them to finalise.
6. Move these submitted requests to the "Mauro Explorer Templates" folder (using MDM UI).
7. Finally, go to the `/templates` page in MDE to view the list of templates available.

# Screenshots

![image](https://user-images.githubusercontent.com/3219480/213732732-214fdf5c-d449-4e11-bbc5-185ea19f3e6f.png)

![image](https://user-images.githubusercontent.com/3219480/213732815-ff4cd031-3c23-4893-9dc9-81d5cb97aa57.png)


