### PR TITLE
gh-219 Display "value" of enumeration in query builder category fields

### DIFF
--- a/src/app/data-explorer/querybuilder/querybuilder.component.html
+++ b/src/app/data-explorer/querybuilder/querybuilder.component.html
@@ -157,7 +157,7 @@ SPDX-License-Identifier: Apache-2.0
         >
           <mat-select [(ngModel)]="rule.value" (ngModelChange)="onChange()">
             <mat-option *ngFor="let opt of options" [value]="opt.value">
-              {{ opt.name }}
+              {{ opt.value }}
             </mat-option>
           </mat-select>
         </mat-form-field>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3219480/214075792-ab9d3d9b-ce9a-4309-8a53-831bd97e781f.png)

Fixes #219 

It should be noted that the change actually uses an enumeration's value, not the "name" (or "key"), since the keys used for some of the OUH model use numbers while the "value" uses a display string - most times both are the same. It should be confirmed if this is correct.