### PR TITLE
gh-206 Fix date formatting bug in meql-pipe

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -41,7 +41,12 @@ import { DataExplorerService } from './data-explorer/data-explorer.service';
 import { Observable } from 'rxjs';
 import { USER_IDLE_CONFIGURATION } from './external/user-idle.service';
 import { LOCALE_ID } from '@angular/core';
-import { DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE } from '@angular/material/core';
+import {
+  DateAdapter,
+  MatDateFormats,
+  MAT_DATE_FORMATS,
+  MAT_DATE_LOCALE,
+} from '@angular/material/core';
 import { MomentDateAdapter } from '@angular/material-moment-adapter';
 
 /**
@@ -100,7 +105,7 @@ const getOpenIdAuthorizeUrl = () => {
 };
 
 // Work around to display and validate dates in gb format
-export const DATE_FORMATS = {
+export const DATE_FORMATS: MatDateFormats = {
   parse: {
     dateInput: 'DD/MM/YYYY',
   },

--- a/src/app/data-explorer/pipes/meql.pipe.spec.ts
+++ b/src/app/data-explorer/pipes/meql.pipe.spec.ts
@@ -45,7 +45,7 @@ describe('MeqlPipe', () => {
       ['transforms field not equal to string', 'Simple String Field', '!=', 'Some Text'],
       ['transforms field equal to number', 'Simple String Field', '=', 0],
       ['transforms field not equal to number', 'Simple String Field', '!=', 99],
-    ])('%s', (testname, field, operator, value) => {
+    ])('%s', (_, field, operator, value) => {
       /*
           Expected example:
 
@@ -57,8 +57,11 @@ describe('MeqlPipe', () => {
         condition: 'and',
         rules: [{ field, operator, value }],
       };
+
+      const expectedValue = typeof value === 'string' ? `"${value}"` : value.toString();
+
       const line1 = `(${newline}`;
-      const line2 = `${tab}"${query.rules[0].field}" ${query.rules[0].operator} "${query.rules[0].value}"${newline}`;
+      const line2 = `${tab}"${query.rules[0].field}" ${query.rules[0].operator} ${expectedValue}${newline}`;
       const line3 = ')';
 
       const actual = pipe.transform(query);
@@ -105,7 +108,7 @@ describe('MeqlPipe', () => {
           ],
         },
       ],
-    ])('%s', (testname, query) => {
+    ])('%s', (_, query) => {
       /*
         Expected example:
 
@@ -259,7 +262,7 @@ describe('MeqlPipe', () => {
           ],
         },
       ],
-    ])('%s', (testname, query) => {
+    ])('%s', (_, query) => {
       /*
         Expected example:
 

--- a/src/app/data-explorer/pipes/meql.pipe.ts
+++ b/src/app/data-explorer/pipes/meql.pipe.ts
@@ -46,21 +46,30 @@ export class MeqlPipe implements PipeTransform {
       quotes = '"';
     }
 
-    if (moment.isMoment(value)) {
-      return `${quotes}${this._date
-        .transform(value.toDate(), 'dd/MM/yyyy')
-        ?.toString()}${quotes}`;
+    if (typeof value === 'number') {
+      return value.toString();
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    else if (moment(value, true).isValid()) {
+      return this.formatDate(value, quotes);
     } else if (isAutocompleteSelectOptionArray(value)) {
       const optionsStr =
         value && value.length > 0 ? value.map((item) => item.name).join(', ') : 'null';
       return `${quotes}${optionsStr}${quotes}`;
+    } else if (value !== undefined && value !== null) {
+      return `${quotes}${value.toString()}${quotes}`;
     } else {
-      if (value !== undefined && value !== null) {
-        return `${quotes}${value.toString()}${quotes}`;
-      } else {
-        return 'null';
-      }
+      return 'null';
     }
+  }
+
+  private formatDate(value: any, quotes = '') {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    const date = moment.isMoment(value) ? value : moment(value);
+
+    return `${quotes}${this._date
+      .transform(date.toDate(), 'dd/MM/yyyy')
+      ?.toString()}${quotes}`;
   }
 
   private parseQuery(


### PR DESCRIPTION
Date values could be moment instances _or_ JSON date strings. Must check both cases to ensure a value can be formatted as a date.

Fixes #206 