### PR TITLE
gh-222: Dynamic size cards in carousel

### DIFF
--- a/src/app/pages/dashboard/dashboard.component.html
+++ b/src/app/pages/dashboard/dashboard.component.html
@@ -72,9 +72,12 @@ SPDX-License-Identifier: Apache-2.0
             <div
               class="mdm-dashboard__request-card"
               routerLink="/requests/{{ request.id }}"
+              [ngStyle]="{ height: currentCardsHeightString }"
             >
               <h3>{{ request.label }}</h3>
-              <p>{{ request.description }}</p>
+              <p [ngStyle]="{ '-webkit-line-clamp': itemCardNumerOfLinesToShow }">
+                {{ request.description }}
+              </p>
             </div>
           </ng-template>
         </p-carousel>

--- a/src/app/pages/dashboard/dashboard.component.scss
+++ b/src/app/pages/dashboard/dashboard.component.scss
@@ -41,7 +41,7 @@ SPDX-License-Identifier: Apache-2.0
     margin-right: 1em;
     padding: 1em;
     cursor: pointer;
-    height: 16rem;
+    max-height: 16rem;
 
     h3 {
       font-weight: 500;

--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -36,8 +36,8 @@ import { SecurityService } from 'src/app/security/security.service';
 export class DashboardComponent implements OnInit {
   searchTerms = '';
   currentUserRequests: DataRequest[] = [];
-  itemCardNumerOfLinesToShow: number = 6;
-  currentCardsHeight: number = 1;
+  itemCardNumerOfLinesToShow = 6;
+  currentCardsHeight = 1;
 
   constructor(
     private security: SecurityService,
@@ -94,7 +94,7 @@ export class DashboardComponent implements OnInit {
     // baseNumberOfCharacters is pure empiric tesing driven
     // there is no way to know for sure, as different combination
     // of letters can ocuppy different space (except in monospace fonts)
-    const baseNumberOfCharacters: number = 30;
+    const baseNumberOfCharacters = 30;
     if (currentUserRequests.length < 1) {
       return;
     } else if (currentUserRequests.length < 2) {

--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -38,9 +38,6 @@ export class DashboardComponent implements OnInit {
   currentUserRequests: DataRequest[] = [];
   itemCardNumerOfLinesToShow: number = 6;
   currentCardsHeight: number = 1;
-  get currentCardsHeightString(): string {
-    return `${this.currentCardsHeight}rem`;
-  }
 
   constructor(
     private security: SecurityService,
@@ -48,6 +45,10 @@ export class DashboardComponent implements OnInit {
     private dataRequests: DataRequestsService,
     private toastr: ToastrService
   ) {}
+
+  get currentCardsHeightString(): string {
+    return `${this.currentCardsHeight}rem`;
+  }
 
   ngOnInit(): void {
     const user = this.security.getSignedInUser();


### PR DESCRIPTION
As mentioned in #222 right now the height of each carousel card are hardcoded and that can produce lots of empty space that seems odd.

This change has some calculations added when we load the requests for the carousel to check the length of the longest description in the requests and calculate how many lines approx the height now is dynamic.

Note: depending on the font and the combination of letters not always 10 characters occupy the same space (expect in monospace fonts, so a lot of these calculations are only based on tests and their are still only approximate values)

example: 16 characters in each line:
VAVAVAVAVAVAVAVA
MMMMMMMMMMMMMMMM

Closes #222