### PR TITLE
gh-240 Add sort control to Request List pages

### DIFF
--- a/src/app/mauro/sort.type.ts
+++ b/src/app/mauro/sort.type.ts
@@ -1,3 +1,5 @@
+import { SortOrder } from '../data-explorer/data-explorer.types';
+
 /*
 Copyright 2022-2023 University of Oxford
 and Health and Social Care Information Centre, also known as NHS Digital
@@ -23,5 +25,31 @@ export class Sort {
 
   static descString(a: string, b: string): number {
     return a > b ? -1 : b > a ? 1 : 0;
+  }
+
+  /**
+   * Compare two objects by string property.
+   * @param a The first object.
+   * @param b The second object.
+   * @param property The name of the property to sort by.
+   * @param order The sort order.
+   * @returns A numeric value that can used to determine if a is less than, greater than, or equal to b.
+   */
+  static compareByString(a: any, b: any, property: string, order: SortOrder): number {
+    return order == 'desc'
+      ? this.descString(a[property], b[property])
+      : this.ascString(a[property], b[property]);
+  }
+
+  /**
+   * Splits a string into the sort parameters it represents.
+   * @param value A string value in the format "{property}-{order}" e.g. "label-desc".
+   * @returns A tuple containing the property name, then the sort order.
+   */
+  static defineSortParams(value: string): [string, SortOrder] {
+    const parts = value.split('-');
+    const sort = parts[0];
+    const order = parts[1] as SortOrder;
+    return [sort, order];
   }
 }

--- a/src/app/mauro/sort.type.ts
+++ b/src/app/mauro/sort.type.ts
@@ -29,6 +29,7 @@ export class Sort {
 
   /**
    * Compare two objects by string property.
+   *
    * @param a The first object.
    * @param b The second object.
    * @param property The name of the property to sort by.
@@ -36,13 +37,14 @@ export class Sort {
    * @returns A numeric value that can used to determine if a is less than, greater than, or equal to b.
    */
   static compareByString(a: any, b: any, property: string, order: SortOrder): number {
-    return order == 'desc'
-      ? this.descString(a[property], b[property])
-      : this.ascString(a[property], b[property]);
+    return order === 'desc'
+      ? this.descString(a[property] as string, b[property] as string)
+      : this.ascString(a[property] as string, b[property] as string);
   }
 
   /**
    * Splits a string into the sort parameters it represents.
+   *
    * @param value A string value in the format "{property}-{order}" e.g. "label-desc".
    * @returns A tuple containing the property name, then the sort order.
    */

--- a/src/app/pages/my-requests/my-requests.component.html
+++ b/src/app/pages/my-requests/my-requests.component.html
@@ -20,26 +20,26 @@ SPDX-License-Identifier: Apache-2.0
   <div class="main-row hero">
     <h1>My Requests</h1>
   </div>
+  <div class="mdm-my-requests__sort-row">
+    <mat-form-field
+      *ngIf="hasMultipleRequestStatus && filteredRequests.length > 0"
+      appearance="outline"
+    >
+      <mat-label>Filter by status</mat-label>
+      <mat-select value="all" (selectionChange)="filterByStatus($event)">
+        <mat-option value="all">All</mat-option>
+        <mat-option value="submitted">Submitted</mat-option>
+        <mat-option value="unsent">Unsent</mat-option>
+      </mat-select>
+    </mat-form-field>
+    <mdm-sort-by
+      [value]="sortBy"
+      [options]="sortByOptions"
+      (valueChange)="selectSortBy($event)"
+    ></mdm-sort-by>
+  </div>
   <div *ngIf="state === 'loading'" class="mdm-my-requests__progress">
     <mat-progress-bar color="primary" mode="indeterminate"></mat-progress-bar>
-  </div>
-  <div *ngIf="hasMultipleRequestStatus && filteredRequests.length > 0" class="col-md-9">
-    <div class="mdm-my-requests__filter">
-      <mat-checkbox
-        color="primary"
-        value="submitted"
-        (change)="filterByStatus($event)"
-      ></mat-checkbox>
-      <label>submitted</label>
-    </div>
-    <div class="mdm-my-requests__filter">
-      <mat-checkbox
-        color="primary"
-        value="unsent"
-        (change)="filterByStatus($event)"
-      ></mat-checkbox>
-      <label>unsent</label>
-    </div>
   </div>
   <div *ngIf="!allRequests || allRequests.length === 0" class="row">
     <p class="text-center">

--- a/src/app/pages/my-requests/my-requests.component.scss
+++ b/src/app/pages/my-requests/my-requests.component.scss
@@ -16,19 +16,11 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-@import "../../../styles/base/all";
-
-$header-filter-margin: 0.5em 1em 0 0;
-
 .mdm-my-requests {
-  &__filter {
-    display: inline-block;
-    margin: $header-filter-margin;
-    padding-bottom: 2px;
-
-    label {
-      margin-left: 0.5em;
-    }
+  &__sort-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
   }
 
   &__request-row__footer {

--- a/src/app/pages/my-requests/my-requests.component.scss
+++ b/src/app/pages/my-requests/my-requests.component.scss
@@ -19,8 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 .mdm-my-requests {
   &__sort-row {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
+    column-gap: 1em;
   }
 
   &__request-row__footer {

--- a/src/app/pages/my-requests/my-requests.component.spec.ts
+++ b/src/app/pages/my-requests/my-requests.component.spec.ts
@@ -16,8 +16,8 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { MatCheckboxChange } from '@angular/material/checkbox';
 import { MatDialog } from '@angular/material/dialog';
+import { MatSelectChange } from '@angular/material/select';
 import { CatalogueItemDomainType } from '@maurodatamapper/mdm-resources';
 import { ToastrService } from 'ngx-toastr';
 import { of, throwError } from 'rxjs';
@@ -206,24 +206,18 @@ describe('MyRequestsComponent', () => {
     });
 
     it('should display all requests if no filters are set', () => {
-      const event = {
-        source: { value: 'unsent' },
-        checked: false,
-      } as MatCheckboxChange;
+      const event = { value: 'all' } as MatSelectChange;
 
       harness.component.filterByStatus(event);
 
-      expect(harness.component.statusFilters).toStrictEqual([]);
+      expect(harness.component.statusFilters).toStrictEqual(['submitted', 'unsent']);
       expect(harness.component.filteredRequests).toStrictEqual(requests);
     });
 
     it.each<DataRequestStatus>(['unsent', 'submitted'])(
       'should display only requests of status %p',
       (status) => {
-        const event = {
-          source: { value: status },
-          checked: true,
-        } as MatCheckboxChange;
+        const event = { value: status } as MatSelectChange;
 
         harness.component.filterByStatus(event);
 
@@ -231,24 +225,6 @@ describe('MyRequestsComponent', () => {
         expect(harness.component.filteredRequests).toStrictEqual(
           requests.filter((r) => r.status === status)
         );
-      }
-    );
-
-    it.each<DataRequestStatus>(['unsent', 'submitted'])(
-      'should include more requests when status %p is removed',
-      (status) => {
-        harness.component.statusFilters = [status];
-        harness.component.filteredRequests = requests.filter((r) => r.status === status);
-
-        const event = {
-          source: { value: status },
-          checked: false,
-        } as MatCheckboxChange;
-
-        harness.component.filterByStatus(event);
-
-        expect(harness.component.statusFilters).toStrictEqual([]);
-        expect(harness.component.filteredRequests).toStrictEqual(requests);
       }
     );
   });

--- a/src/app/pages/my-requests/my-requests.component.ts
+++ b/src/app/pages/my-requests/my-requests.component.ts
@@ -23,7 +23,6 @@ import { catchError, EMPTY, finalize, throwError } from 'rxjs';
 import {
   DataRequest,
   DataRequestStatus,
-  SortOrder,
 } from 'src/app/data-explorer/data-explorer.types';
 import { DataRequestsService } from 'src/app/data-explorer/data-requests.service';
 import { SortByOption } from 'src/app/data-explorer/sort-by/sort-by.component';

--- a/src/app/pages/template-requests/template-requests.component.html
+++ b/src/app/pages/template-requests/template-requests.component.html
@@ -30,6 +30,14 @@ SPDX-License-Identifier: Apache-2.0
       </p>
     </div>
   </div>
+  <div class="mdm-template-requests__sort-row">
+    <span class="spacer"></span>
+    <mdm-sort-by
+      [value]="sortBy"
+      [options]="sortByOptions"
+      (valueChange)="selectSortBy($event)"
+    ></mdm-sort-by>
+  </div>
   <div *ngIf="state === 'loading'" class="mdm-template-requests__progress">
     <mat-progress-bar color="primary" mode="indeterminate"></mat-progress-bar>
   </div>

--- a/src/app/pages/template-requests/template-requests.component.scss
+++ b/src/app/pages/template-requests/template-requests.component.scss
@@ -16,3 +16,10 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
+.mdm-template-requests {
+  &__sort-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+}


### PR DESCRIPTION
- Updated "My Requests" and "Templates" pages
- Can sort by label in ascending or descending order
- Updated the "My Request" filter too

Resolves #240 

# Limitations

All sorting must be done on the client-side because the Mauro endpoints used for fetching the lists do not support sort arguments. Also no date fields are returned in the list objects, meaning `label` is currently the only way to sort requests.

# Screenshots

![image](https://user-images.githubusercontent.com/3219480/217239268-2bd35afd-a1ec-4801-9ee4-29a07c9cfb72.png)

![image](https://user-images.githubusercontent.com/3219480/217239318-9c7b90dc-f416-4d82-b67f-9ae84db8a513.png)
