### PR TITLE
gh-277 Do not allow query editing if no data elements are available

### DIFF
--- a/src/app/pages/my-request-detail/my-request-detail.component.html
+++ b/src/app/pages/my-request-detail/my-request-detail.component.html
@@ -44,14 +44,14 @@ SPDX-License-Identifier: Apache-2.0
     <mdm-data-query-row
       queryType="cohort"
       [condition]="cohortQuery"
-      [readOnly]="request.status === 'submitted'"
+      [readOnly]="request.status === 'submitted' || isEmpty"
       createRouterLink="queries/cohort"
       editRouterLink="queries/cohort"
     ></mdm-data-query-row>
     <mdm-data-query-row
       queryType="data"
       [condition]="dataQuery"
-      [readOnly]="request.status === 'submitted'"
+      [readOnly]="request.status === 'submitted' || isEmpty"
       createRouterLink="queries/data"
       editRouterLink="queries/data"
     ></mdm-data-query-row>

--- a/src/app/pages/my-request-detail/my-request-detail.component.ts
+++ b/src/app/pages/my-request-detail/my-request-detail.component.ts
@@ -104,6 +104,7 @@ export class MyRequestDetailComponent implements OnInit {
     rules: [],
   };
   dataSchemas: DataSchema[] = [];
+  isEmpty = false;
 
   allSelected: SelectionChange = {
     changedBy: { instigator: 'parent' },
@@ -458,6 +459,8 @@ export class MyRequestDetailComponent implements OnInit {
       .subscribe(([dataSchemas, intersections]) => {
         this.dataSchemas = [];
         this.dataSchemas = dataSchemas;
+        this.isEmpty =
+          this.dataSchemaService.getDataRequestElements(this.dataSchemas).length === 0;
         this.sourceTargetIntersections = intersections;
       });
   }

--- a/src/app/pages/request-query/request-query.component.ts
+++ b/src/app/pages/request-query/request-query.component.ts
@@ -23,6 +23,7 @@ import { QueryBuilderConfig } from 'angular2-query-builder';
 import { ToastrService } from 'ngx-toastr';
 import { catchError, EMPTY, finalize, forkJoin, switchMap } from 'rxjs';
 import { BroadcastService } from 'src/app/core/broadcast.service';
+import { StateRouterService } from 'src/app/core/state-router.service';
 import {
   DataElementSearchResult,
   DataRequest,
@@ -65,7 +66,8 @@ export class RequestQueryComponent implements OnInit, IModelPage {
     private dataRequests: DataRequestsService,
     private toastr: ToastrService,
     private broadcast: BroadcastService,
-    private queryBuilderService: QueryBuilderService
+    private queryBuilderService: QueryBuilderService,
+    private stateRouter: StateRouterService
   ) {}
 
   ngOnInit(): void {
@@ -97,6 +99,11 @@ export class RequestQueryComponent implements OnInit, IModelPage {
           return this.errorResponse('There was a problem finding your request queries.');
         }),
         switchMap(([dataElements, query]) => {
+          if (dataElements.length === 0) {
+            this.stateRouter.navigateTo([this.backRouterLink, this.backRouterRequestId]);
+            return EMPTY;
+          }
+
           return this.queryBuilderService.setupConfig(
             this.mapDataElements(dataElements),
             query


### PR DESCRIPTION
- Check if request is "empty" and if so hide the create/edit query buttons
- Modify request query page to auto redirect back to the request if loading and no data elements were found
- Test that request-query page redirects when no data elements available

Fixes #277 