### PR TITLE
gh 257: Fix callstack bug in big requests

### DIFF
--- a/src/app/data-explorer/data-class-row/data-class-row.component.html
+++ b/src/app/data-explorer/data-class-row/data-class-row.component.html
@@ -23,10 +23,10 @@ SPDX-License-Identifier: Apache-2.0
         <mat-checkbox
           *ngIf="canDelete"
           class="mdm-data-class-row__header-title-checkbox"
-          [checked]="dataClassWithElements?.dataClass?.isSelected"
-          (change)="classChecked()"
+          [(ngModel)]="(dataClassWithElements?.dataClass)!.isSelected"
+          (ngModelChange)="ngModelOnChange()"
         ></mat-checkbox>
-        <h3>{{ dataClassWithElements?.dataClass?.label }}</h3>
+        <h3>{{ (dataClassWithElements?.dataClass)!.label }}</h3>
       </div>
     </span>
     <span class="mdm-data-class-row__header-button-panel">
@@ -73,10 +73,8 @@ SPDX-License-Identifier: Apache-2.0
       [sourceTargetIntersections]="sourceTargetIntersections"
       [suppressViewRequestsDialogButton]="true"
       (requestAddDelete)="handleRequestAddDelete($event)"
-      (checked)="onSelectElement($event)"
       [nestedPadding]="true"
-      [classSelected]="classSelected"
-      (setRemoveSelectedButtonDisabledEvent)="handleSetRemoveSelectedButtonDisable()"
+      (updateAllChildrenSelected)="updateAllChildrenSelectedHandler()"
     >
     </mdm-data-element-row>
   </div>

--- a/src/app/data-explorer/data-class-row/data-class-row.component.spec.ts
+++ b/src/app/data-explorer/data-class-row/data-class-row.component.spec.ts
@@ -61,14 +61,14 @@ describe('DataClassRowComponent', () => {
     expect(harness.component.dataClassWithElements).toBeUndefined();
   });
 
-  it('should not raise a classCheckedEvent when checked but has no data class', () => {
-    const emitSpy = jest.spyOn(harness.component.classCheckedEvent, 'emit');
-    harness.component.classChecked();
+  it('should not raise a updateAllChildrenSelected when model changes but has no data class', () => {
+    const emitSpy = jest.spyOn(harness.component.updateAllChildrenSelected, 'emit');
+    harness.component.ngModelOnChange();
     expect(emitSpy).not.toHaveBeenCalled();
   });
 
-  it('should raise a classCheckedEvent when has a data class is checked', () => {
-    const emitSpy = jest.spyOn(harness.component.classCheckedEvent, 'emit');
+  it('should raise a updateAllChildrenSelected when has a data class, and model changes', () => {
+    const emitSpy = jest.spyOn(harness.component.updateAllChildrenSelected, 'emit');
 
     const dataClassWithElements: DataClassWithElements = {
       dataClass: {
@@ -79,7 +79,7 @@ describe('DataClassRowComponent', () => {
     };
 
     harness.component.dataClassWithElements = dataClassWithElements;
-    harness.component.classChecked();
+    harness.component.ngModelOnChange();
 
     expect(emitSpy).toHaveBeenCalled();
   });
@@ -163,11 +163,8 @@ describe('DataClassRowComponent mdm-data-element-row', () => {
     const mdmDataElementRowComponent = dom.query(
       (de) => de.name === 'mdm-data-element-row'
     );
-    const emitSpy = jest.spyOn(component.setRemoveSelectedButtonDisabledEvent, 'emit');
-    mdmDataElementRowComponent.triggerEventHandler(
-      'setRemoveSelectedButtonDisabledEvent',
-      {}
-    );
+    const emitSpy = jest.spyOn(component.updateAllChildrenSelected, 'emit');
+    mdmDataElementRowComponent.triggerEventHandler('updateAllChildrenSelected', {});
     expect(emitSpy).toHaveBeenCalledWith();
   });
 

--- a/src/app/data-explorer/data-class-row/data-class-row.component.ts
+++ b/src/app/data-explorer/data-class-row/data-class-row.component.ts
@@ -16,23 +16,12 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import {
-  Component,
-  EventEmitter,
-  Input,
-  OnChanges,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { RequestElementAddDeleteEvent } from 'src/app/shared/data-element-in-request/data-element-in-request.component';
 import {
   DataClassWithElements,
   DataElementSearchResult,
   DataItemDeleteEvent,
-  SelectableDataElementSearchResultCheckedEvent,
-  SelectionChange,
-  SelectionChangedBy,
 } from '../data-explorer.types';
 import { DataAccessRequestsSourceTargetIntersections } from '../data-requests.service';
 
@@ -41,29 +30,25 @@ import { DataAccessRequestsSourceTargetIntersections } from '../data-requests.se
   templateUrl: './data-class-row.component.html',
   styleUrls: ['./data-class-row.component.scss'],
 })
-export class DataClassRowComponent implements OnInit, OnChanges {
+export class DataClassRowComponent implements OnInit {
   @Input() dataClassWithElements?: DataClassWithElements;
   @Input() suppressViewRequestsDialogButton = false;
   @Input() canDelete = true;
   @Input() requestName = '';
   @Input() requestId = '';
-  @Input() schemaSelected?: SelectionChange;
   @Input() sourceTargetIntersections: DataAccessRequestsSourceTargetIntersections;
 
   @Output() deleteItemEvent = new EventEmitter<DataItemDeleteEvent>();
   @Output() requestAddDelete = new EventEmitter<RequestElementAddDeleteEvent>();
-  @Output() classCheckedEvent = new EventEmitter();
-  @Output() setRemoveSelectedButtonDisabledEvent = new EventEmitter();
+  @Output() updateAllChildrenSelected = new EventEmitter();
 
   state: 'idle' | 'loading' = 'idle';
 
   visible = true;
 
-  classSelected: SelectionChange = {
-    changedBy: { instigator: 'parent' },
-    isSelected: false,
-  };
   classElements: DataElementSearchResult[] = [];
+
+  allChildrenSelected: boolean = false;
 
   constructor() {
     this.sourceTargetIntersections = {
@@ -78,15 +63,23 @@ export class DataClassRowComponent implements OnInit, OnChanges {
     }
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes.schemaSelected) {
-      if (
-        this.dataClassWithElements &&
-        this.schemaSelected?.changedBy?.instigator === 'parent'
-      ) {
-        this.selectClass(this.schemaSelected.isSelected, { instigator: 'parent' });
-      }
+  /**
+   * When any of the children component
+   * changes states, we need to update
+   * our state accordingly.  Also, after
+   * changing our state we should comunicate
+   * that to our ancestors for them to update
+   *  their state.
+   */
+  updateAllChildrenSelectedHandler() {
+    if (!this.dataClassWithElements) {
+      return;
     }
+    this.dataClassWithElements.dataClass.isSelected = this.classElements.every(
+      (dataElement) => dataElement.isSelected
+    );
+
+    this.updateAllChildrenSelected.emit();
   }
 
   toggleCollapse(): void {
@@ -95,10 +88,6 @@ export class DataClassRowComponent implements OnInit, OnChanges {
 
   handleRequestAddDelete(event: RequestElementAddDeleteEvent) {
     this.requestAddDelete.emit(event);
-  }
-
-  handleSetRemoveSelectedButtonDisable() {
-    this.setRemoveSelectedButtonDisabled();
   }
 
   handleDeleteItemEvent(event: DataItemDeleteEvent) {
@@ -114,56 +103,43 @@ export class DataClassRowComponent implements OnInit, OnChanges {
     }
   }
 
-  classChecked() {
-    if (!this.dataClassWithElements) {
+  /**
+   * When the class checkbox is clicked
+   * we need to select or deselect all our
+   * children, and also emit the event
+   * for my ancestor to update its state.
+   */
+  ngModelOnChange() {
+    if (!this.dataClassWithElements?.dataClass) {
       return;
     }
 
-    this.selectClass(!this.dataClassWithElements?.dataClass?.isSelected ?? false, {
-      instigator: 'parent',
+    if (this.dataClassWithElements?.dataClass?.isSelected) {
+      this.checkAllChildDataElements();
+    } else {
+      this.uncheckAllChildDataElements();
+    }
+
+    this.updateAllChildrenSelected.emit();
+  }
+
+  private checkAllChildDataElements() {
+    if (!this.classElements) {
+      return;
+    }
+
+    this.classElements.forEach((element) => {
+      element.isSelected = true;
     });
-
-    this.classCheckedEvent.emit();
   }
 
-  onSelectElement(event: SelectableDataElementSearchResultCheckedEvent) {
-    event.item.isSelected = event.checked;
-    const selectedItemList = this.classElements.filter((item) => item.isSelected);
-    this.setClassSelected(selectedItemList);
-    this.setRemoveSelectedButtonDisabled();
-  }
-
-  /**
-   * Disable the 'Remove Selected' button unless some elements are selected in the current request
-   */
-  private setRemoveSelectedButtonDisabled() {
-    this.setRemoveSelectedButtonDisabledEvent.emit();
-  }
-
-  /**
-   * If all the elements are selected, select the parent class. If a single element is not
-   * selected, deselect the parent class.
-   */
-  private setClassSelected(selectedItemList: DataElementSearchResult[]) {
-    if (this.dataClassWithElements) {
-      this.selectClass(this.classElements.length === selectedItemList.length, {
-        instigator: 'child',
-      });
-      this.classCheckedEvent.emit(this.dataClassWithElements.dataClass.isSelected);
-    }
-  }
-
-  private selectClass(value: boolean, changedBy: SelectionChangedBy) {
-    if (this.dataClassWithElements) {
-      this.dataClassWithElements.dataClass.isSelected = value;
+  private uncheckAllChildDataElements() {
+    if (!this.classElements) {
+      return;
     }
 
-    if (this.classSelected) {
-      const classSelected: SelectionChange = {
-        changedBy,
-        isSelected: value,
-      };
-      this.classSelected = classSelected;
-    }
+    this.classElements.forEach((element) => {
+      element.isSelected = false;
+    });
   }
 }

--- a/src/app/data-explorer/data-class-row/data-class-row.component.ts
+++ b/src/app/data-explorer/data-class-row/data-class-row.component.ts
@@ -48,7 +48,7 @@ export class DataClassRowComponent implements OnInit {
 
   classElements: DataElementSearchResult[] = [];
 
-  allChildrenSelected: boolean = false;
+  allChildrenSelected = false;
 
   constructor() {
     this.sourceTargetIntersections = {
@@ -69,7 +69,7 @@ export class DataClassRowComponent implements OnInit {
    * our state accordingly.  Also, after
    * changing our state we should comunicate
    * that to our ancestors for them to update
-   *  their state.
+   * their state.
    */
   updateAllChildrenSelectedHandler() {
     if (!this.dataClassWithElements) {

--- a/src/app/data-explorer/data-element-row/data-element-row.component.html
+++ b/src/app/data-explorer/data-element-row/data-element-row.component.html
@@ -26,8 +26,8 @@ SPDX-License-Identifier: Apache-2.0
         <mat-checkbox
           *ngIf="canDelete"
           class="mdm-data-element-row__header-title-checkbox"
-          [checked]="item.isSelected"
-          (change)="itemChecked($event)"
+          [(ngModel)]="item.isSelected"
+          (ngModelChange)="onNgModelChange()"
         ></mat-checkbox>
         <a
           class="mdm-data-element-row__header-link"

--- a/src/app/data-explorer/data-element-row/data-element-row.component.spec.ts
+++ b/src/app/data-explorer/data-element-row/data-element-row.component.spec.ts
@@ -89,27 +89,16 @@ describe('DataElementRowComponent_DataElementInRequest', () => {
   });
   */
 
-  it('should raise a checked event when checkbox is checked', () => {
+  it('should raise a updateAllChildrenSelected event when ngModelChange is triggered', () => {
+    // Arrange
     const component = harness.component;
-    const emitSpy = jest.spyOn(component.checked, 'emit');
-    const dom = harness.fixture.debugElement;
-    harness.detectChanges();
-    const checkboxElement = dom.query((de) => de.name === 'mat-checkbox');
-    const event: MatCheckboxChange = {
-      source: checkboxElement.nativeElement,
-      checked: true,
-    };
-    expect(component.item?.isSelected).toBe(false);
-    checkboxElement.triggerEventHandler('change', event);
-    expect(emitSpy).toHaveBeenCalledWith({ item: component.item, checked: true });
-    expect(component.item!.isSelected).toBe(true); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+    const emitSpy = jest.spyOn(component.updateAllChildrenSelected, 'emit');
 
-    emitSpy.mockReset();
-    event.checked = false;
-    checkboxElement.nativeElement.value = false;
-    checkboxElement.triggerEventHandler('change', event);
-    expect(emitSpy).toHaveBeenCalledWith({ item: component.item, checked: false });
-    expect(component.item!.isSelected).toBe(false); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+    // Act
+    component.onNgModelChange();
+
+    // Assert
+    expect(emitSpy).toHaveBeenCalled();
   });
 
   it('should raise an event when data-element-in-request emits a requestAddDelete event', () => {

--- a/src/app/data-explorer/data-element-row/data-element-row.component.ts
+++ b/src/app/data-explorer/data-element-row/data-element-row.component.ts
@@ -16,21 +16,13 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import {
-  Component,
-  EventEmitter,
-  Input,
-  OnChanges,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import {
   CreateRequestEvent,
   RequestElementAddDeleteEvent,
 } from 'src/app/shared/data-element-in-request/data-element-in-request.component';
 import { DataElementSearchResultComponent } from '../data-element-search-result/data-element-search-result.component';
-import { SelectionChange, DataItemDeleteEvent } from '../data-explorer.types';
+import { DataItemDeleteEvent } from '../data-explorer.types';
 
 @Component({
   selector: 'mdm-data-element-row',
@@ -39,17 +31,17 @@ import { SelectionChange, DataItemDeleteEvent } from '../data-explorer.types';
 })
 export class DataElementRowComponent
   extends DataElementSearchResultComponent
-  implements OnInit, OnChanges
+  implements OnInit
 {
   @Input() suppressViewRequestsDialogButton = false;
   @Input() canDelete = true;
   @Input() nestedPadding = false;
-  @Input() classSelected?: SelectionChange;
 
   @Output() deleteItemEvent = new EventEmitter<DataItemDeleteEvent>();
   @Output() requestAddDelete = new EventEmitter<RequestElementAddDeleteEvent>();
   @Output() requestCreated = new EventEmitter<CreateRequestEvent>();
   @Output() setRemoveSelectedButtonDisabledEvent = new EventEmitter();
+  @Output() updateAllChildrenSelected = new EventEmitter();
 
   padding = 'default';
 
@@ -57,13 +49,18 @@ export class DataElementRowComponent
     this.padding = this.nestedPadding ? 'nested' : 'default';
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes.classSelected) {
-      if (this.item && this.classSelected?.changedBy?.instigator === 'parent') {
-        this.item.isSelected = this.classSelected.isSelected;
-        this.setRemoveSelectedButtonDisabledEvent.emit();
-      }
+  /**
+   * When the selection changes
+   * we emit this event for the
+   * ancestor components to refresh
+   * some of their variables.
+   */
+  onNgModelChange() {
+    if (!this.item) {
+      return;
     }
+
+    this.updateAllChildrenSelected.emit();
   }
 
   handleRequestAddDelete(event: RequestElementAddDeleteEvent) {

--- a/src/app/data-explorer/data-schema-row/data-schema-row.component.html
+++ b/src/app/data-explorer/data-schema-row/data-schema-row.component.html
@@ -23,8 +23,8 @@ SPDX-License-Identifier: Apache-2.0
         <mat-checkbox
           *ngIf="canDelete"
           class="mdm-data-schema-row__header-title-checkbox"
-          [checked]="dataSchema.schema.isSelected"
-          (change)="schemaChecked($event)"
+          [(ngModel)]="dataSchema.schema.isSelected"
+          (ngModelChange)="onNgModelChange()"
         ></mat-checkbox>
         <h3>{{ dataSchema.schema.label }}</h3>
       </div>
@@ -73,11 +73,9 @@ SPDX-License-Identifier: Apache-2.0
       [requestName]="requestName"
       [requestId]="requestId"
       [suppressViewRequestsDialogButton]="true"
-      [schemaSelected]="schemaSelected"
-      (classCheckedEvent)="onSelectClass()"
       [sourceTargetIntersections]="sourceTargetIntersections"
-      (setRemoveSelectedButtonDisabledEvent)="handleSetRemoveSelectedButtonDisable()"
       (requestAddDelete)="handleRequestAddDelete($event)"
+      (updateAllChildrenSelected)="updateAllChildrenSelectedHandler()"
     >
     </mdm-data-class-row>
   </div>

--- a/src/app/data-explorer/data-schema-row/data-schema-row.component.ts
+++ b/src/app/data-explorer/data-schema-row/data-schema-row.component.ts
@@ -16,25 +16,14 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import {
-  Component,
-  EventEmitter,
-  Input,
-  OnChanges,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { MatCheckboxChange } from '@angular/material/checkbox';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { RequestElementAddDeleteEvent } from 'src/app/shared/data-element-in-request/data-element-in-request.component';
 import {
-  DataClassWithElements,
   DataElementSearchResult,
   DataItemDeleteEvent,
   DataRequestQueryType,
   DataSchema,
   SelectionChange,
-  SelectionChangedBy,
 } from '../data-explorer.types';
 import { DataAccessRequestsSourceTargetIntersections } from '../data-requests.service';
 import { DataSchemaService } from 'src/app/mauro/data-schema-service';
@@ -44,19 +33,17 @@ import { DataSchemaService } from 'src/app/mauro/data-schema-service';
   templateUrl: './data-schema-row.component.html',
   styleUrls: ['./data-schema-row.component.scss'],
 })
-export class DataSchemaRowComponent implements OnInit, OnChanges {
+export class DataSchemaRowComponent implements OnInit {
   @Input() dataSchema?: DataSchema;
   @Input() requestName = '';
   @Input() requestId = '';
   @Input() suppressViewRequestsDialogButton = false;
   @Input() canDelete = true;
   @Input() sourceTargetIntersections: DataAccessRequestsSourceTargetIntersections;
-  @Input() allSelected?: SelectionChange;
 
   @Output() deleteItemEvent = new EventEmitter<DataItemDeleteEvent>();
   @Output() requestAddDelete = new EventEmitter<RequestElementAddDeleteEvent>();
-  @Output() schemaCheckedEvent = new EventEmitter();
-  @Output() setRemoveSelectedButtonDisabledEvent = new EventEmitter();
+  @Output() updateAllOrSomeChildrenSelected = new EventEmitter();
 
   visible = true;
 
@@ -82,24 +69,12 @@ export class DataSchemaRowComponent implements OnInit, OnChanges {
     }
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes.allSelected) {
-      if (this.allSelected?.changedBy?.instigator === 'parent') {
-        this.selectSchema(this.allSelected.isSelected, { instigator: 'parent' });
-      }
-    }
-  }
-
   toggleCollapse(): void {
     this.visible = !this.visible;
   }
 
   handleRequestAddDelete(event: RequestElementAddDeleteEvent) {
     this.requestAddDelete.emit(event);
-  }
-
-  handleSetRemoveSelectedButtonDisable() {
-    this.setRemoveSelectedButtonDisabledEvent.emit();
   }
 
   handleDeleteItemEvent(event: DataItemDeleteEvent) {
@@ -115,48 +90,55 @@ export class DataSchemaRowComponent implements OnInit, OnChanges {
     }
   }
 
-  schemaChecked(event: MatCheckboxChange) {
+  /**
+   * When the schema checkbox is clicked
+   * we need to select or deselect all our
+   * descendents, and also emit the event
+   * for my ancestor to update its state.
+   */
+  onNgModelChange() {
     if (!this.dataSchema) {
       return;
     }
 
-    this.selectSchema(event.checked, {
-      instigator: 'parent',
-    });
-
-    this.schemaCheckedEvent.emit();
-  }
-
-  onSelectClass() {
-    if (this.dataSchema) {
-      const selectedItemList = this.dataSchema.dataClasses.filter(
-        (item) => item.dataClass.isSelected
-      );
-      this.setSchemaSelected(selectedItemList);
+    if (this.dataSchema.schema.isSelected) {
+      this.selectOrUnselectAllChildDataClassesAndItsChildren(true);
+    } else {
+      this.selectOrUnselectAllChildDataClassesAndItsChildren(false);
     }
+
+    this.updateAllOrSomeChildrenSelected.emit();
   }
 
   /**
-   * If all the elements are selected, select the parent class. If a single element is not
-   * selected, deselect the parent class.
+   * When any of the children component
+   * changes states, we need to update
+   * our state accordingly.  Also, after
+   * changing our state we should comunicate
+   * that to our ancestors for them to update
+   *  their state.
    */
-  private setSchemaSelected(selectedItemList: DataClassWithElements[]) {
-    if (this.dataSchema) {
-      this.selectSchema(this.dataSchema.dataClasses.length === selectedItemList.length, {
-        instigator: 'child',
-      });
-      this.schemaCheckedEvent.emit(this.dataSchema.schema.isSelected);
+  updateAllChildrenSelectedHandler() {
+    if (!this.dataSchema) {
+      return;
     }
+    this.dataSchema.schema.isSelected = this.schemaElements.every(
+      (dataElement) => dataElement.isSelected
+    );
+
+    this.updateAllOrSomeChildrenSelected.emit();
   }
 
-  private selectSchema(value: boolean, changedBy: SelectionChangedBy) {
-    if (this.dataSchema) {
-      this.dataSchema.schema.isSelected = value;
+  private selectOrUnselectAllChildDataClassesAndItsChildren(valueToSet: boolean) {
+    if (!this.dataSchema?.dataClasses) {
+      return;
     }
-    const schemaSelected: SelectionChange = {
-      changedBy,
-      isSelected: value,
-    };
-    this.schemaSelected = schemaSelected;
+
+    this.dataSchema?.dataClasses.forEach((dataClass) => {
+      dataClass.dataClass.isSelected = valueToSet;
+      dataClass.dataElements.forEach((dataElement) => {
+        dataElement.isSelected = valueToSet;
+      });
+    });
   }
 }

--- a/src/app/data-explorer/data-schema-row/data-schema-row.component.ts
+++ b/src/app/data-explorer/data-schema-row/data-schema-row.component.ts
@@ -116,7 +116,7 @@ export class DataSchemaRowComponent implements OnInit {
    * our state accordingly.  Also, after
    * changing our state we should comunicate
    * that to our ancestors for them to update
-   *  their state.
+   * their state.
    */
   updateAllChildrenSelectedHandler() {
     if (!this.dataSchema) {

--- a/src/app/pages/my-request-detail/my-request-detail.component.html
+++ b/src/app/pages/my-request-detail/my-request-detail.component.html
@@ -67,14 +67,14 @@ SPDX-License-Identifier: Apache-2.0
       *ngIf="request.status === 'unsent'"
       class="mdm-my-request__request-elements-selectall"
     >
-      <mat-checkbox (change)="onSelectAll($event)" [checked]="selectAllElements"
+      <mat-checkbox (change)="onSelectAll()" [checked]="allElementsSelected"
         >Select all</mat-checkbox
       >
       <button
         class="ms-4"
         mat-raised-button
         color="primary"
-        [disabled]="removeSelectedButtonDisabled"
+        [disabled]="!anyElementSelected"
         (click)="removeSelected()"
       >
         Remove selected ...
@@ -95,9 +95,7 @@ SPDX-License-Identifier: Apache-2.0
         [requestName]="request.label"
         [requestId]="request.id ?? ''"
         [sourceTargetIntersections]="sourceTargetIntersections"
-        [allSelected]="allSelected"
-        (schemaCheckedEvent)="onSelectSchema()"
-        (setRemoveSelectedButtonDisabledEvent)="handleSetRemoveSelectedButtonDisable()"
+        (updateAllOrSomeChildrenSelected)="updateAllOrSomeChildrenSelectedHandler()"
       >
       </mdm-data-schema-row>
     </div>

--- a/src/app/pages/my-request-detail/my-request-detail.component.ts
+++ b/src/app/pages/my-request-detail/my-request-detail.component.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { MatDialogRef } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
 import {


### PR DESCRIPTION
The main problem was that change events on the data elements row was emitting events that caused the father components to change the item within the data element component causing the change event to emit again causing an infinite loop.

I have refactored how it works, data element component now uses ngModelChange which only triggers when the users change it, so no update from its father will trigger it.

Data class and data schema components check now is based on if all its children are selected or not. This gets updated by handling the event from the children each time there is a change of value.

Updated the tests to accommodate the new workflow, but it should not cause the components to dramatically change its behaviour, just the way of achieving such behaviour.

closes #257 