### PR TITLE
Fixed checkmarks on dataelement and search.

### DIFF
--- a/src/app/pages/data-element/data-element.component.ts
+++ b/src/app/pages/data-element/data-element.component.ts
@@ -254,18 +254,16 @@ export class DataElementComponent implements OnInit {
     };
   }
 
-
   private subscribeDataRequestChanges() {
     this.broadcast
       .on('data-request-added')
       .pipe(
         takeUntil(this.unsubscribe$),
-        switchMap(() => this.loadIntersections()),
-        map((intersections) => (this.sourceTargetIntersections = intersections))
+        switchMap(() => this.loadIntersections())
       )
       .subscribe((intersections) => {
+        this.sourceTargetIntersections = intersections;
         this.broadcast.dispatch('data-intersections-refreshed', intersections);
       });
-}
-
+  }
 }

--- a/src/app/pages/data-element/data-element.component.ts
+++ b/src/app/pages/data-element/data-element.component.ts
@@ -254,15 +254,18 @@ export class DataElementComponent implements OnInit {
     };
   }
 
+
   private subscribeDataRequestChanges() {
     this.broadcast
       .on('data-request-added')
-      .pipe(takeUntil(this.unsubscribe$))
-      .subscribe(() => {
-        this.loadIntersections().subscribe((intersections) => {
-          this.sourceTargetIntersections = intersections;
-          this.broadcast.dispatch('data-intersections-refreshed', intersections);
-        });
+      .pipe(
+        takeUntil(this.unsubscribe$),
+        switchMap(() => this.loadIntersections()),
+        map((intersections) => (this.sourceTargetIntersections = intersections))
+      )
+      .subscribe((intersections) => {
+        this.broadcast.dispatch('data-intersections-refreshed', intersections);
       });
-  }
+}
+
 }

--- a/src/app/pages/my-bookmarks/my-bookmarks.component.ts
+++ b/src/app/pages/my-bookmarks/my-bookmarks.component.ts
@@ -20,7 +20,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { MatCheckboxChange } from '@angular/material/checkbox';
 import { Uuid } from '@maurodatamapper/mdm-resources';
 import { ToastrService } from 'ngx-toastr';
-import { forkJoin, map, of, Subject, switchMap, takeUntil, throwError } from 'rxjs';
+import { forkJoin, of, Subject, switchMap, takeUntil, throwError } from 'rxjs';
 import { BroadcastService } from 'src/app/core/broadcast.service';
 import { BookmarkService } from 'src/app/data-explorer/bookmark.service';
 import { DataExplorerService } from 'src/app/data-explorer/data-explorer.service';
@@ -137,10 +137,10 @@ export class MyBookmarksComponent implements OnInit, OnDestroy {
       .on('data-request-added')
       .pipe(
         takeUntil(this.unsubscribe$),
-        switchMap(() => this.loadIntersections(this.userBookmarks)),
-        map((intersections) => (this.sourceTargetIntersections = intersections))
+        switchMap(() => this.loadIntersections(this.userBookmarks))
       )
       .subscribe((intersections) => {
+        this.sourceTargetIntersections = intersections;
         this.broadcast.dispatch('data-intersections-refreshed', intersections);
       });
   }

--- a/src/app/pages/my-request-detail/my-request-detail.component.ts
+++ b/src/app/pages/my-request-detail/my-request-detail.component.ts
@@ -33,10 +33,12 @@ import {
   filter,
   finalize,
   forkJoin,
+  map,
   Observable,
   of,
   Subject,
   switchMap,
+  takeUntil,
   tap,
 } from 'rxjs';
 import { BroadcastService } from 'src/app/core/broadcast.service';
@@ -135,6 +137,7 @@ export class MyRequestDetailComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.initialiseRequest();
+    this.subscribeDataRequestChanges();
   }
 
   ngOnDestroy(): void {
@@ -535,6 +538,19 @@ export class MyRequestDetailComponent implements OnInit, OnDestroy {
     }
     // refresh the request
     this.setRequest(this.request);
+  }
+
+  private subscribeDataRequestChanges() {
+    this.broadcastService
+      .on('data-request-added')
+      .pipe(
+        takeUntil(this.unsubscribe$),
+        switchMap(() => this.loadIntersections(this.dataSchemas)),
+        map((intersections) => (this.sourceTargetIntersections = intersections))
+      )
+      .subscribe((intersections) => {
+        this.broadcastService.dispatch('data-intersections-refreshed', intersections);
+      });
   }
 
   /**

--- a/src/app/pages/my-request-detail/my-request-detail.component.ts
+++ b/src/app/pages/my-request-detail/my-request-detail.component.ts
@@ -33,7 +33,6 @@ import {
   filter,
   finalize,
   forkJoin,
-  map,
   Observable,
   of,
   Subject,
@@ -545,10 +544,10 @@ export class MyRequestDetailComponent implements OnInit, OnDestroy {
       .on('data-request-added')
       .pipe(
         takeUntil(this.unsubscribe$),
-        switchMap(() => this.loadIntersections(this.dataSchemas)),
-        map((intersections) => (this.sourceTargetIntersections = intersections))
+        switchMap(() => this.loadIntersections(this.dataSchemas))
       )
       .subscribe((intersections) => {
+        this.sourceTargetIntersections = intersections;
         this.broadcastService.dispatch('data-intersections-refreshed', intersections);
       });
   }

--- a/src/app/pages/my-request-detail/my-request-detail.component.ts
+++ b/src/app/pages/my-request-detail/my-request-detail.component.ts
@@ -37,7 +37,6 @@ import {
   of,
   Subject,
   switchMap,
-  takeUntil,
   tap,
 } from 'rxjs';
 import { BroadcastService } from 'src/app/core/broadcast.service';
@@ -136,7 +135,6 @@ export class MyRequestDetailComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.initialiseRequest();
-    this.subscribeDataRequestChanges();
   }
 
   ngOnDestroy(): void {
@@ -527,18 +525,6 @@ export class MyRequestDetailComponent implements OnInit, OnDestroy {
         }
       })
     );
-  }
-
-  private subscribeDataRequestChanges() {
-    this.broadcastService
-      .on('data-request-added')
-      .pipe(takeUntil(this.unsubscribe$))
-      .subscribe(() => {
-        this.loadIntersections(this.dataSchemas).subscribe((intersections) => {
-          this.sourceTargetIntersections = intersections;
-          this.broadcastService.dispatch('data-intersections-refreshed', intersections);
-        });
-      });
   }
 
   private processRemoveDataElementResponse(result: boolean, message: string) {

--- a/src/app/pages/search-listing/search-listing.component.ts
+++ b/src/app/pages/search-listing/search-listing.component.ts
@@ -30,7 +30,6 @@ import {
   takeUntil,
   combineLatest,
   throwError,
-  map,
 } from 'rxjs';
 import { DataModelService } from 'src/app/mauro/data-model.service';
 import { KnownRouterPath, StateRouterService } from 'src/app/core/state-router.service';
@@ -389,13 +388,13 @@ export class SearchListingComponent implements OnInit, OnDestroy {
       .on('data-request-added')
       .pipe(
         takeUntil(this.unsubscribe$),
-        switchMap(() => this.loadIntersections()),
-        map((intersections) => (this.sourceTargetIntersections = intersections))
+        switchMap(() => this.loadIntersections())
       )
       .subscribe((intersections) => {
+        this.sourceTargetIntersections = intersections;
         this.broadcast.dispatch('data-intersections-refreshed', intersections);
       });
-}
+  }
 
   private setBackButtonProperties(source: string, search?: string) {
     this.backRouterLink = source === 'browse' ? '/browse' : '/search';

--- a/src/app/shared/data-element-in-request/data-element-in-request.component.scss
+++ b/src/app/shared/data-element-in-request/data-element-in-request.component.scss
@@ -38,6 +38,10 @@ section {
   margin-bottom: 0.5rem;
 }
 
+.fa-circle-check {
+  margin-left: 6px;
+}
+
 $triangle-center: 77.5%;
 $vertical-offset: 6px;
 $horizontal-offset: 8px;

--- a/src/app/shared/data-element-in-request/data-element-in-request.component.ts
+++ b/src/app/shared/data-element-in-request/data-element-in-request.component.ts
@@ -200,6 +200,9 @@ export class DataElementInRequestComponent implements OnInit, OnDestroy {
               };
               this.requestAddDelete.emit(addDeleteEventData);
             });
+            // Really this is an update rather than add, but broadcasting data-request-added has the effect we want
+            // i.e. forcing intersections to be refreshed
+            this.broadcast.dispatch('data-request-added');
           }
 
           const dataElementInstances: DataElementInstance[] = dataElements


### PR DESCRIPTION
Fixed checkmarks not appearing in page when adding an element to a request.
Affects data element view and search/results view.

Possible continueation.
Implement broadcast state sync service to update intersections on data request view. search view and data element view to sync state across multiple tabs.