### PR TITLE
gh-253 - Add types integer and decimal to query builder. 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -225,7 +225,7 @@ pipeline {
   post {
     always {
       outputTestResults()
-      zulipNotification(topic: 'mdm-explorer')
+      // zulipNotification(topic: 'mdm-explorer')
     }
   }
 }

--- a/src/app/data-explorer/data-explorer.module.ts
+++ b/src/app/data-explorer/data-explorer.module.ts
@@ -44,6 +44,7 @@ import { MeqlPipe } from './pipes/meql.pipe';
 import { MeqlOutputComponent } from './meql-output/meql-output.component';
 import { DataRequestRowComponent } from './data-request-row/data-request-row.component';
 import { DataQueryRowComponent } from './data-query-row/data-query-row.component';
+import { NumberFormatDirective } from './querybuilder/directives/number-format.directive';
 import { EditRequestDialogComponent } from './edit-request-dialog/edit-request-dialog.component';
 import { SelectionExpandedDialogComponent } from './selection-expanded-dialog/selection-expanded-dialog.component';
 import { SelectionCompactComponent } from './selection-compact/selection-compact.component';
@@ -73,6 +74,7 @@ import { SelectionCompactComponent } from './selection-compact/selection-compact
     MeqlOutputComponent,
     DataRequestRowComponent,
     DataQueryRowComponent,
+    NumberFormatDirective,
     EditRequestDialogComponent,
     SelectionExpandedDialogComponent,
     SelectionCompactComponent,
@@ -96,6 +98,7 @@ import { SelectionCompactComponent } from './selection-compact/selection-compact
     MeqlOutputComponent,
     DataRequestRowComponent,
     DataQueryRowComponent,
+    NumberFormatDirective,
     SelectionCompactComponent,
   ],
   providers: [

--- a/src/app/data-explorer/querybuilder/directives/number-format.directive.spec.ts
+++ b/src/app/data-explorer/querybuilder/directives/number-format.directive.spec.ts
@@ -1,0 +1,130 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { TestBed } from '@angular/core/testing';
+import { FormControl, NgControl } from '@angular/forms';
+import { NumberFormatDirective } from './number-format.directive';
+
+class MockNgControl extends NgControl {
+  control = new FormControl();
+  viewToModelUpdate() {}
+}
+
+describe('IntegerOnlyDirective', () => {
+  let directive: NumberFormatDirective;
+  const mockNgControl = new MockNgControl();
+
+  let integerInputSpy: jest.SpyInstance;
+  let decimalInputSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [NumberFormatDirective, { provide: NgControl, useValue: mockNgControl }],
+    });
+
+    directive = TestBed.inject(NumberFormatDirective);
+
+    // Hookup spy's.
+    integerInputSpy = jest.spyOn(directive, 'attemptToParseIntegerInput');
+    decimalInputSpy = jest.spyOn(directive, 'attemptToParseDecimalInput');
+
+    // Need to emit an initial value for the control as it skips the emission
+    // of the initial value.
+    directive.ngOnInit();
+    mockNgControl.control.setValue(null);
+  });
+
+  it('should create an instance', () => {
+    expect(directive).toBeTruthy();
+  });
+
+  describe('the control flow of the subscription', () => {
+    it('should not call either parsing method if value of control is null', () => {
+      mockNgControl.control.setValue(null);
+
+      expect(integerInputSpy).not.toHaveBeenCalled();
+      expect(decimalInputSpy).not.toHaveBeenCalled();
+    });
+
+    it('should call attemptToParseIntegerInput if numberFormat is integer', () => {
+      directive.numberFormat = 'integer';
+      mockNgControl.control.setValue('123');
+      expect(integerInputSpy).toHaveBeenCalledWith('123');
+    });
+
+    it('should call attemptToParseDecimalInput if numberFormat is decimal', () => {
+      directive.numberFormat = 'decimal';
+      mockNgControl.control.setValue('123');
+      expect(decimalInputSpy).toHaveBeenCalledWith('123');
+    });
+  });
+
+  describe('attemptToParseIntegerInput()', () => {
+    it.each([
+      ['-', '-'],
+      ['-', '---'],
+      ['-', '-='],
+      ['-', '-asdb'],
+      ['-', '-.'],
+      ['-', '-..'],
+      ['', '.'],
+      ['', '..'],
+      [-12, '-12'],
+      [-1234, '-12.34'],
+      [12, '12s'],
+      [12, '12-'],
+      [12, '12.'],
+      [12, '12sdf'],
+      [1234, '12sdf34'],
+      [123, '123'],
+      [123456, '123.456'],
+    ])('should return %p when the input is %p', (expected, input) => {
+      directive.numberFormat = 'integer';
+      mockNgControl.control.setValue(input);
+
+      expect(integerInputSpy).toHaveBeenCalledWith(input);
+      expect(integerInputSpy).toHaveReturnedWith(expected);
+    });
+  });
+
+  describe('attemptToParseDecimalInput()', () => {
+    it.each([
+      ['-', '-'],
+      ['-', '--'],
+      ['.', '.'],
+      ['.', '..'],
+      ['-.', '-.'],
+      ['-.', '----.'],
+      ['-.', '-.....'],
+      [-0.1, '----.1'],
+      [-12, '-12'],
+      [-12.34, '-12.34'],
+      ['12.', '12.'],
+      [12, '12-'],
+      [12, '12sdf'],
+      [123, '123'],
+      [123.456, '123.456'],
+    ])('should return %p when the input is %p', (expected, input) => {
+      directive.numberFormat = 'decimal';
+      mockNgControl.control.setValue(input);
+
+      expect(decimalInputSpy).toHaveBeenCalledWith(input);
+      expect(decimalInputSpy).toHaveReturnedWith(expected);
+    });
+  });
+});

--- a/src/app/data-explorer/querybuilder/directives/number-format.directive.ts
+++ b/src/app/data-explorer/querybuilder/directives/number-format.directive.ts
@@ -1,0 +1,134 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Directive, Input, OnDestroy, OnInit } from '@angular/core';
+import { NgControl } from '@angular/forms';
+import { Subscription } from 'rxjs';
+import { map, skip } from 'rxjs/operators';
+
+export type NumberFormat = 'integer' | 'decimal';
+
+@Directive({
+  selector: 'input[mdmNumberFormat]',
+})
+export class NumberFormatDirective implements OnInit, OnDestroy {
+  @Input() numberFormat: NumberFormat = 'decimal';
+
+  private subscription!: Subscription;
+
+  constructor(private ngControl: NgControl) {}
+
+  ngOnInit() {
+    const ctrl = this.ngControl.control;
+
+    if (!ctrl) {
+      return;
+    }
+
+    this.subscription = ctrl.valueChanges
+      .pipe(
+        skip(1), // Skip the initial value of the form control. It might already be properly set.
+        map((v: string | null) => {
+          if (v == null) {
+            return v;
+          }
+
+          return this.numberFormat === 'integer'
+            ? this.attemptToParseIntegerInput(v)
+            : this.attemptToParseDecimalInput(v);
+        })
+      )
+      .subscribe((v) => ctrl.setValue(v, { emitEvent: false }));
+  }
+
+  ngOnDestroy() {
+    this.subscription?.unsubscribe();
+  }
+
+  attemptToParseIntegerInput(input: string): number | string {
+    let partialParse: string = input;
+    // If input is any number of '-' symbols, just trim and wait for more input
+    // because the user might be in the process of entering a negative number.
+    if (!this.beginsWithSingleMinusSign(input)) {
+      partialParse = this.removeRepeatedAllowedSymbols(input);
+    }
+
+    // Remove all nonInteger symbols (anything not a digit or a '-' sign).
+    const nonIntegerNumberSymbols = /[^\d-]*/g;
+    const onlyNumberSymbols = partialParse.replace(nonIntegerNumberSymbols, '');
+
+    // Attempt to parse as integer. If not possible to parse,
+    // return the cleaned string containing only number symbols.
+    if (onlyNumberSymbols) {
+      const parsedInt = parseInt(onlyNumberSymbols, 10);
+      if (!isNaN(parsedInt)) {
+        return parsedInt;
+      }
+    }
+    return onlyNumberSymbols;
+  }
+
+  attemptToParseDecimalInput(input: string): number | string {
+    let partialParse: string = input;
+
+    // Clean the string if it isn't meet some formatting rules.
+    if (
+      !this.beginsWithSingleMinusSign(input) ||
+      !this.endsWithSingleDecimalPoint(input)
+    ) {
+      partialParse = this.removeRepeatedAllowedSymbols(input);
+    }
+
+    // Await further input before trying to parse as a float.
+    if (this.endsWithSingleDecimalPoint(partialParse)) {
+      return partialParse;
+    }
+
+    // First, remove characters that aren't in the following set {'-', '.', integers}.
+    const nonDecimalNumberSymbols = /[^\d-.]/g;
+    const onlyNumberSymbols = partialParse.replace(nonDecimalNumberSymbols, '');
+
+    // Attempt to parse as a floating point number. If not possible to parse,
+    // return the cleaned string containing only number symbols.
+    if (onlyNumberSymbols) {
+      const parsedFloat = parseFloat(onlyNumberSymbols);
+      if (!isNaN(parsedFloat)) {
+        return parsedFloat;
+      }
+    }
+    return onlyNumberSymbols;
+  }
+
+  // Allowed symbols are '-', '.' or ',' characters.
+  private removeRepeatedAllowedSymbols(input: string): string {
+    const repeatedAllowedSymbols = /([-,.])\1+/g;
+    return input.replace(repeatedAllowedSymbols, '$1'); // replace with the matched character
+  }
+
+  // Allow for decimal point to be ',' as they do in France.
+  private endsWithSingleDecimalPoint(input: string): boolean {
+    return (
+      (input.endsWith('.') && input.indexOf('.') === input.lastIndexOf('.')) ||
+      (input.endsWith(',') && input.indexOf(',') === input.lastIndexOf(','))
+    );
+  }
+
+  private beginsWithSingleMinusSign(input: string): boolean {
+    return input.startsWith('-') && input.indexOf('-') === input.lastIndexOf('-');
+  }
+}

--- a/src/app/data-explorer/querybuilder/querybuilder.component.html
+++ b/src/app/data-explorer/querybuilder/querybuilder.component.html
@@ -238,15 +238,42 @@ SPDX-License-Identifier: Apache-2.0
           </mat-select>
         </mat-form-field>
       </ng-container>
-      <!-- Number -->
+      <!-- Integer -->
       <ng-container
-        *queryInput="let rule; let field = field; type: 'number'; let onChange = onChange"
+        *queryInput="
+          let rule;
+          let field = field;
+          type: 'integer';
+          let onChange = onChange
+        "
       >
-        <mat-form-field appearance="outline" class="query-builder-number">
+        <mat-form-field appearance="outline">
           <input
             matInput
+            mdmNumberFormat
+            [numberFormat]="'integer'"
+            type="text"
             [(ngModel)]="rule.value"
-            type="number"
+            (ngModelChange)="onChange()"
+          />
+        </mat-form-field>
+      </ng-container>
+      <!-- Decimal -->
+      <ng-container
+        *queryInput="
+          let rule;
+          let field = field;
+          type: 'decimal';
+          let onChange = onChange
+        "
+      >
+        <mat-form-field appearance="outline">
+          <input
+            matInput
+            mdmNumberFormat
+            [numberFormat]="'decimal'"
+            [(ngModel)]="rule.value"
+            type="text"
             (ngModelChange)="onChange()"
           />
         </mat-form-field>

--- a/src/app/data-explorer/querybuilder/querybuilder.component.ts
+++ b/src/app/data-explorer/querybuilder/querybuilder.component.ts
@@ -57,6 +57,8 @@ export class QueryBuilderComponent implements OnInit {
     // Is also used to extend some default operators
     /* eslint-disable */
     string: ['=', '!=', 'contains', 'like', 'startswith', 'endswith'],
+    integer: ['=', '!=', '<', '<=', '>', '>='],
+    decimal: ['=', '!=', '<', '<=', '>', '>='],
     datetime: ['=', '!=', '>', '<', '=>', '=<'],
     terminology: ['in', 'not in'],
     /* eslint-enable */
@@ -84,7 +86,7 @@ export class QueryBuilderComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    // For all 'terminology' fields, initialse the search result sets for the controls
+    // For all 'terminology' fields, initialise the search result sets for the controls
     Object.entries(this.config.fields)
       .filter(([_, field]) => field.type === 'terminology')
       .forEach(([name, _]) => (this.termSearchResults[name] = { count: 0, options: [] }));


### PR DESCRIPTION
Allow for distinction between integer and decimal types in the query builder input field. 

Solution:

Create a custom directive mdmNumberFormat and attach to the input's with the correct format set. This is meant to be an approximation of `<input type=number />` that works across all browers. It does this by piping the user input through one of two parsing methods. If possible, we return a number, if not a string for the user to continue updating. 

Testing: 

There is a test suite testing various inputs, but of course have a manual play too. The most notable issue is that copy and pasting can end up producing strange string after filtering, for example "--..--.." would be mapped to "-.-." rather than say "-." which is what you might expect based on the control flow. 

These changes are paired with: https://github.com/MauroDataMapper-Plugins/mdm-plugin-explorer/pull/25

