### PR TITLE
gh-312: Shared with community

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Set the api root in the enviroment
 create a distribution with the custom api set 
 `npm run dist`
 
-OPTIONAL - you can check `root/dist/yourSnapshotName/main.*` and note apiEndpoint to see if it took
+OPTIONAL - you can check `root/dist/yourSnapshotName/main.*` and note mauroCoreEndpoint to see if it took
 
 deploy your distribution to a httpserver
 install the httpserver `npm install --global http-server`

--- a/jest.config.js
+++ b/jest.config.js
@@ -35,7 +35,7 @@ module.exports = {
       stringifyContentPathRegex: "\\.html",
     },
     $ENV: {
-      apiEndpoint: "test-endpoint",
+      mauroCoreEndpoint: "test-endpoint",
     },
   },
   moduleNameMapper: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "rxjs": "7.4.0",
         "tinycolor2": "1.6.0",
         "tslib": "2.3.1",
+        "uuid": "^9.0.0",
         "zone.js": "0.11.5"
       },
       "devDependencies": {
@@ -3962,6 +3963,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@angular/cli/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@angular/common": {
@@ -15453,6 +15463,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/jest-junit/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/jest-leak-detector": {
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-28.1.3.tgz",
@@ -20981,6 +21000,15 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/socks": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
@@ -22126,10 +22154,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -25449,6 +25476,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
         }
       }
     },
@@ -34000,6 +34033,12 @@
           "requires": {
             "ansi-regex": "^4.1.0"
           }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
         }
       }
     },
@@ -38026,6 +38065,14 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "socks": {
@@ -38885,10 +38932,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "rxjs": "7.4.0",
     "tinycolor2": "1.6.0",
     "tslib": "2.3.1",
+    "uuid": "^9.0.0",
     "zone.js": "0.11.5"
   },
   "devDependencies": {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -288,11 +288,11 @@ export class AppComponent implements OnInit, OnDestroy {
 
   private setupSignedInUser(user?: UserDetails | null) {
     this.signedInUserProfileImageSrc = user
-      ? `${environment.apiEndpoint}/catalogueUsers/${user.id}/image`
+      ? `${environment.mauroCoreEndpoint}/catalogueUsers/${user.id}/image`
       : undefined;
     this.signedInUser = user;
     this.signedInUserProfileImageSrc = user
-      ? `${environment.apiEndpoint}/catalogueUsers/${user.id}/image`
+      ? `${environment.mauroCoreEndpoint}/catalogueUsers/${user.id}/image`
       : undefined;
   }
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -125,7 +125,7 @@ export const DATE_FORMATS: MatDateFormats = {
     CoreModule,
     SharedModule,
     MauroModule.forRoot({
-      apiEndpoint: environment.apiEndpoint,
+      apiEndpoint: environment.mauroCoreEndpoint,
       defaultHttpRequestOptions: {
         withCredentials: true,
       },

--- a/src/app/data-explorer/data-explorer.module.ts
+++ b/src/app/data-explorer/data-explorer.module.ts
@@ -48,6 +48,7 @@ import { NumberFormatDirective } from './querybuilder/directives/number-format.d
 import { EditDataSpecificationDialogComponent } from './edit-data-specification-dialog/edit-data-specification-dialog.component';
 import { SelectionExpandedDialogComponent } from './selection-expanded-dialog/selection-expanded-dialog.component';
 import { SelectionCompactComponent } from './selection-compact/selection-compact.component';
+import { ShareDataSpecificationDialogComponent } from './share-data-specification-dialog/share-data-specification-dialog.component';
 
 @NgModule({
   declarations: [
@@ -78,6 +79,7 @@ import { SelectionCompactComponent } from './selection-compact/selection-compact
     EditDataSpecificationDialogComponent,
     SelectionExpandedDialogComponent,
     SelectionCompactComponent,
+    ShareDataSpecificationDialogComponent,
   ],
   imports: [CoreModule, SharedModule, QueryBuilderModule],
   exports: [

--- a/src/app/data-explorer/data-explorer.module.ts
+++ b/src/app/data-explorer/data-explorer.module.ts
@@ -49,6 +49,7 @@ import { EditDataSpecificationDialogComponent } from './edit-data-specification-
 import { SelectionExpandedDialogComponent } from './selection-expanded-dialog/selection-expanded-dialog.component';
 import { SelectionCompactComponent } from './selection-compact/selection-compact.component';
 import { ShareDataSpecificationDialogComponent } from './share-data-specification-dialog/share-data-specification-dialog.component';
+import { FilterByComponent } from './filter-by/filter-by.component';
 
 @NgModule({
   declarations: [
@@ -80,6 +81,7 @@ import { ShareDataSpecificationDialogComponent } from './share-data-specificatio
     SelectionExpandedDialogComponent,
     SelectionCompactComponent,
     ShareDataSpecificationDialogComponent,
+    FilterByComponent,
   ],
   imports: [CoreModule, SharedModule, QueryBuilderModule],
   exports: [
@@ -102,6 +104,7 @@ import { ShareDataSpecificationDialogComponent } from './share-data-specificatio
     DataQueryRowComponent,
     NumberFormatDirective,
     SelectionCompactComponent,
+    FilterByComponent,
   ],
   providers: [
     {

--- a/src/app/data-explorer/data-specification-row/data-specification-row.component.html
+++ b/src/app/data-explorer/data-specification-row/data-specification-row.component.html
@@ -50,6 +50,15 @@ SPDX-License-Identifier: Apache-2.0
       <span class="fa-solid fa-pen-to-square"></span>
       Edit
     </button>
+    <button
+      *ngIf="showShareButton"
+      mat-raised-button
+      color="primary"
+      (click)="onShareClick()"
+    >
+      <span class="fa-solid fa-share-nodes"></span>
+      Share
+    </button>
   </ng-container>
   <ng-container>
     <div *ngIf="dataSpecification.description">

--- a/src/app/data-explorer/data-specification-row/data-specification-row.component.ts
+++ b/src/app/data-explorer/data-specification-row/data-specification-row.component.ts
@@ -33,10 +33,12 @@ export class DataSpecificationRowComponent {
   @Input() showSubmitButton = false;
   @Input() showCopyButton = false;
   @Input() showEditButton = false;
+  @Input() showShareButton = false;
 
   @Output() submitClick = new EventEmitter<void>();
   @Output() copyClick = new EventEmitter<void>();
   @Output() editClick = new EventEmitter<void>();
+  @Output() shareClick = new EventEmitter<void>();
 
   onSubmitClick() {
     this.submitClick.emit();
@@ -48,5 +50,9 @@ export class DataSpecificationRowComponent {
 
   onEditClick() {
     this.editClick.emit();
+  }
+
+  onShareClick() {
+    this.shareClick.emit();
   }
 }

--- a/src/app/data-explorer/data-specification.service.ts
+++ b/src/app/data-explorer/data-specification.service.ts
@@ -75,6 +75,10 @@ import { DialogService } from './dialog.service';
 import { RulesService } from '../mauro/rules.service';
 import { ResearchPluginService } from '../mauro/research-plugin.service';
 import { EditDataSpecificationDialogOptions as EditDataSpecificationDialogOptions } from './edit-data-specification-dialog/edit-data-specification-dialog.component';
+import {
+  ShareDataSpecificationDialogOptions,
+  ShareDataSpecificationDialogResponse,
+} from './share-data-specification-dialog/share-data-specification-dialog.component';
 
 /**
  * A collection of data specifications and their intersections with target models.
@@ -181,6 +185,40 @@ export class DataSpecificationService {
         }),
         finalize(() => {
           this.broadcast.loading({ isLoading: false });
+        })
+      );
+  }
+
+  /**
+   * Opens a dialog for the user to set the specification
+   * as readable by any authenticated users or not.
+   *
+   * @param shared whether the {@link DataSpecification} is
+   * currently readable by any authenticated users or not.
+   * @returns an observable containing a {@link ShareDataSpecificationDialogResponse}
+   */
+  shareWithDialog(shared: boolean): Observable<ShareDataSpecificationDialogResponse> {
+    const user = this.security.getSignedInUser();
+    if (!user) return EMPTY;
+
+    const dialogData: ShareDataSpecificationDialogOptions = {
+      sharedWithCommunity: shared,
+    };
+
+    return this.dialogs
+      .shareWithCommunity(dialogData)
+      .afterClosed()
+      .pipe(
+        filter((response: any) => !!response),
+        map((response: ShareDataSpecificationDialogResponse) => {
+          return response;
+        }),
+        catchError((error) => {
+          this.toastr.error(
+            `There was a problem sharing the specification. ${error}`,
+            'Data specification edition error'
+          );
+          return EMPTY;
         })
       );
   }

--- a/src/app/data-explorer/data-specification.service.ts
+++ b/src/app/data-explorer/data-specification.service.ts
@@ -75,10 +75,7 @@ import { DialogService } from './dialog.service';
 import { RulesService } from '../mauro/rules.service';
 import { ResearchPluginService } from '../mauro/research-plugin.service';
 import { EditDataSpecificationDialogOptions as EditDataSpecificationDialogOptions } from './edit-data-specification-dialog/edit-data-specification-dialog.component';
-import {
-  ShareDataSpecificationDialogOptions,
-  ShareDataSpecificationDialogResponse,
-} from './share-data-specification-dialog/share-data-specification-dialog.component';
+import { ShareDataSpecificationDialogInputOutput } from './share-data-specification-dialog/share-data-specification-dialog.component';
 
 /**
  * A collection of data specifications and their intersections with target models.
@@ -195,13 +192,13 @@ export class DataSpecificationService {
    *
    * @param shared whether the {@link DataSpecification} is
    * currently readable by any authenticated users or not.
-   * @returns an observable containing a {@link ShareDataSpecificationDialogResponse}
+   * @returns an observable containing a {@link ShareDataSpecificationDialogInputOutput}
    */
-  shareWithDialog(shared: boolean): Observable<ShareDataSpecificationDialogResponse> {
+  shareWithDialog(shared: boolean): Observable<ShareDataSpecificationDialogInputOutput> {
     const user = this.security.getSignedInUser();
     if (!user) return EMPTY;
 
-    const dialogData: ShareDataSpecificationDialogOptions = {
+    const dialogData: ShareDataSpecificationDialogInputOutput = {
       sharedWithCommunity: shared,
     };
 
@@ -210,9 +207,6 @@ export class DataSpecificationService {
       .afterClosed()
       .pipe(
         filter((response: any) => !!response),
-        map((response: ShareDataSpecificationDialogResponse) => {
-          return response;
-        }),
         catchError((error) => {
           this.toastr.error(
             `There was a problem sharing the specification. ${error}`,

--- a/src/app/data-explorer/dialog.service.ts
+++ b/src/app/data-explorer/dialog.service.ts
@@ -58,8 +58,7 @@ import {
 } from './success-dialog/success-dialog.component';
 import {
   ShareDataSpecificationDialogComponent,
-  ShareDataSpecificationDialogOptions,
-  ShareDataSpecificationDialogResponse,
+  ShareDataSpecificationDialogInputOutput,
 } from './share-data-specification-dialog/share-data-specification-dialog.component';
 
 @Injectable({
@@ -144,11 +143,11 @@ export class DialogService {
     );
   }
 
-  shareWithCommunity(data: ShareDataSpecificationDialogOptions) {
+  shareWithCommunity(data: ShareDataSpecificationDialogInputOutput) {
     return this.matDialog.open<
       ShareDataSpecificationDialogComponent,
-      ShareDataSpecificationDialogOptions,
-      ShareDataSpecificationDialogResponse
+      ShareDataSpecificationDialogInputOutput,
+      ShareDataSpecificationDialogInputOutput
     >(ShareDataSpecificationDialogComponent, { minWidth: 500, data });
   }
 }

--- a/src/app/data-explorer/dialog.service.ts
+++ b/src/app/data-explorer/dialog.service.ts
@@ -56,6 +56,11 @@ import {
   SuccessDialogComponent,
   SuccessDialogData,
 } from './success-dialog/success-dialog.component';
+import {
+  ShareDataSpecificationDialogComponent,
+  ShareDataSpecificationDialogOptions,
+  ShareDataSpecificationDialogResponse,
+} from './share-data-specification-dialog/share-data-specification-dialog.component';
 
 @Injectable({
   providedIn: 'root',
@@ -137,5 +142,13 @@ export class DialogService {
         data,
       }
     );
+  }
+
+  shareWithCommunity(data: ShareDataSpecificationDialogOptions) {
+    return this.matDialog.open<
+      ShareDataSpecificationDialogComponent,
+      ShareDataSpecificationDialogOptions,
+      ShareDataSpecificationDialogResponse
+    >(ShareDataSpecificationDialogComponent, { minWidth: 500, data });
   }
 }

--- a/src/app/data-explorer/filter-by/filter-by.component.html
+++ b/src/app/data-explorer/filter-by/filter-by.component.html
@@ -1,4 +1,4 @@
-/*
+<!--
 Copyright 2022-2023 University of Oxford
 and Health and Social Care Information Centre, also known as NHS Digital
 
@@ -15,20 +15,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
-*/
-.mdm-template-data-specifications {
-  &__sort-row {
-    display: flex;
-    justify-content: space-between;
-    margin: 1em 0;
-
-    .vertically-aligned {
-      display: flex;
-      align-items: center;
-
-      > * {
-        margin-left: 1em;
-      }
-    }
-  }
-}
+-->
+<mat-form-field appearance="outline">
+  <mat-label>Filter By</mat-label>
+  <mat-select
+    [value]="value"
+    [disableOptionCentering]="true"
+    (selectionChange)="select($event)"
+  >
+    <mat-option *ngFor="let option of options" [value]="option">
+      {{ option.displayName }}
+    </mat-option>
+  </mat-select>
+</mat-form-field>

--- a/src/app/data-explorer/filter-by/filter-by.component.scss
+++ b/src/app/data-explorer/filter-by/filter-by.component.scss
@@ -16,19 +16,3 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-.mdm-template-data-specifications {
-  &__sort-row {
-    display: flex;
-    justify-content: space-between;
-    margin: 1em 0;
-
-    .vertically-aligned {
-      display: flex;
-      align-items: center;
-
-      > * {
-        margin-left: 1em;
-      }
-    }
-  }
-}

--- a/src/app/data-explorer/filter-by/filter-by.component.spec.ts
+++ b/src/app/data-explorer/filter-by/filter-by.component.spec.ts
@@ -1,0 +1,57 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatSelect, MatSelectChange } from '@angular/material/select';
+import {
+  ComponentHarness,
+  setupTestModuleForComponent,
+} from 'src/app/testing/testing.helpers';
+import { MockComponent, MockDirective } from 'ng-mocks';
+import { FilterByComponent } from './filter-by.component';
+
+describe('SortByComponent', () => {
+  let harness: ComponentHarness<FilterByComponent>;
+
+  beforeEach(async () => {
+    harness = await setupTestModuleForComponent(FilterByComponent, {
+      declarations: [
+        MockComponent(MatFormField),
+        MockDirective(MatLabel),
+        MockComponent(MatSelect),
+      ],
+      providers: [],
+    });
+  });
+
+  it('should create', () => {
+    expect(harness.isComponentCreated).toBeTruthy();
+  });
+
+  it('should fire an update when new option selected', () => {
+    const sortByOption = { value: 'val', displayName: 'name' };
+    const changedSortByOption = { value: 'new-val', displayName: 'new-name' };
+    const matChange = { value: changedSortByOption } as MatSelectChange;
+    const spy = jest.spyOn(harness.component.valueChange, 'emit');
+
+    harness.component.value = sortByOption;
+    harness.component.select(matChange);
+
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/src/app/data-explorer/filter-by/filter-by.component.ts
+++ b/src/app/data-explorer/filter-by/filter-by.component.ts
@@ -16,19 +16,25 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-.mdm-template-data-specifications {
-  &__sort-row {
-    display: flex;
-    justify-content: space-between;
-    margin: 1em 0;
+import { Component, Input, EventEmitter, Output } from '@angular/core';
+import { MatSelectChange } from '@angular/material/select';
 
-    .vertically-aligned {
-      display: flex;
-      align-items: center;
+export interface FilterByOption {
+  value: string;
+  displayName: string;
+}
 
-      > * {
-        margin-left: 1em;
-      }
-    }
+@Component({
+  selector: 'mdm-filter-by',
+  templateUrl: './filter-by.component.html',
+  styleUrls: ['./filter-by.component.scss'],
+})
+export class FilterByComponent {
+  @Input() value?: FilterByOption;
+  @Input() options?: FilterByOption[];
+  @Output() valueChange = new EventEmitter<FilterByOption>();
+
+  select(change: MatSelectChange) {
+    this.valueChange.emit(change.value as FilterByOption);
   }
 }

--- a/src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component.html
+++ b/src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component.html
@@ -1,4 +1,4 @@
-<!-- 
+<!--
 Copyright 2022-2023 University of Oxford
 and Health and Social Care Information Centre, also known as NHS Digital
 
@@ -15,7 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
- -->
+-->
+
 <h1 mat-dialog-title>Share data specification</h1>
 <mat-dialog-content class="shared_specification_dialog_content">
   <mat-checkbox

--- a/src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component.html
+++ b/src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component.html
@@ -1,0 +1,32 @@
+<!-- 
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+ -->
+<h1 mat-dialog-title>Share data specification</h1>
+<mat-dialog-content class="shared_specification_dialog_content">
+  <mat-checkbox
+    class="example-margin"
+    [(ngModel)]="dialogCheckboxValue"
+    [checked]="dialogCheckboxValue"
+  >
+    Share with the Community
+  </mat-checkbox>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-stroked-button color="primary" (click)="close()">Close</button>
+  <button mat-flat-button color="primary" (click)="update()">Share</button>
+</mat-dialog-actions>

--- a/src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component.html
+++ b/src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component.html
@@ -29,5 +29,12 @@ SPDX-License-Identifier: Apache-2.0
 </mat-dialog-content>
 <mat-dialog-actions align="end">
   <button mat-stroked-button color="primary" (click)="close()">Close</button>
-  <button mat-flat-button color="primary" (click)="update()">Share</button>
+  <button
+    mat-flat-button
+    color="primary"
+    (click)="update()"
+    [disabled]="initialSharedValue === dialogCheckboxValue"
+  >
+    Share
+  </button>
 </mat-dialog-actions>

--- a/src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component.scss
+++ b/src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component.scss
@@ -1,0 +1,21 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+.shared_specification_dialog_content {
+  overflow: hidden !important;
+}

--- a/src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component.spec.ts
+++ b/src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component.spec.ts
@@ -16,25 +16,35 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ShareDataSpecificationDialogComponent } from './share-data-specification-dialog.component';
+import {
+  ComponentHarness,
+  setupTestModuleForComponent,
+} from 'src/app/testing/testing.helpers';
+import { createMatDialogRefStub } from 'src/app/testing/stubs/mat-dialog.stub';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 
 describe('ShareDataSpecificationDialogComponent', () => {
-  let component: ShareDataSpecificationDialogComponent;
-  let fixture: ComponentFixture<ShareDataSpecificationDialogComponent>;
+  let harness: ComponentHarness<ShareDataSpecificationDialogComponent>;
+  const dialogRefStub = createMatDialogRefStub();
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ShareDataSpecificationDialogComponent],
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(ShareDataSpecificationDialogComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    harness = await setupTestModuleForComponent(ShareDataSpecificationDialogComponent, {
+      providers: [
+        {
+          provide: MatDialogRef,
+          useValue: dialogRefStub,
+        },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: [],
+        },
+      ],
+    });
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(harness.isComponentCreated).toBeTruthy();
   });
 });

--- a/src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component.spec.ts
+++ b/src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component.spec.ts
@@ -1,0 +1,40 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ShareDataSpecificationDialogComponent } from './share-data-specification-dialog.component';
+
+describe('ShareDataSpecificationDialogComponent', () => {
+  let component: ShareDataSpecificationDialogComponent;
+  let fixture: ComponentFixture<ShareDataSpecificationDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ShareDataSpecificationDialogComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ShareDataSpecificationDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component.ts
+++ b/src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component.ts
@@ -36,7 +36,7 @@ export interface ShareDataSpecificationDialogResponse {
 export class ShareDataSpecificationDialogComponent implements OnInit {
   initialSharedValue: boolean;
   dialogCheckboxValue: boolean;
-  checkBoxDisabled: boolean = false;
+  checkBoxDisabled = false;
 
   constructor(
     public dialogRef: MatDialogRef<

--- a/src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component.ts
+++ b/src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component.ts
@@ -20,11 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 import { Component, Inject, OnInit, Optional } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
-export interface ShareDataSpecificationDialogOptions {
-  sharedWithCommunity: boolean;
-}
-
-export interface ShareDataSpecificationDialogResponse {
+export interface ShareDataSpecificationDialogInputOutput {
   sharedWithCommunity: boolean;
 }
 
@@ -41,11 +37,11 @@ export class ShareDataSpecificationDialogComponent implements OnInit {
   constructor(
     public dialogRef: MatDialogRef<
       ShareDataSpecificationDialogComponent,
-      ShareDataSpecificationDialogResponse
+      ShareDataSpecificationDialogInputOutput
     >,
     @Inject(MAT_DIALOG_DATA)
     @Optional()
-    private data: ShareDataSpecificationDialogOptions
+    private data: ShareDataSpecificationDialogInputOutput
   ) {
     this.initialSharedValue = this.data.sharedWithCommunity;
     this.dialogCheckboxValue = this.data.sharedWithCommunity;

--- a/src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component.ts
+++ b/src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component.ts
@@ -19,10 +19,6 @@ SPDX-License-Identifier: Apache-2.0
 
 import { Component, Inject, OnInit, Optional } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { ToastrService } from 'ngx-toastr';
-import { MatCheckboxChange } from '@angular/material/checkbox';
-import { DataModelService } from 'src/app/mauro/data-model.service';
-import { Uuid } from '@maurodatamapper/mdm-resources';
 
 export interface ShareDataSpecificationDialogOptions {
   sharedWithCommunity: boolean;

--- a/src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component.ts
+++ b/src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component.ts
@@ -1,0 +1,69 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+import { Component, Inject, OnInit, Optional } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ToastrService } from 'ngx-toastr';
+import { MatCheckboxChange } from '@angular/material/checkbox';
+import { DataModelService } from 'src/app/mauro/data-model.service';
+import { Uuid } from '@maurodatamapper/mdm-resources';
+
+export interface ShareDataSpecificationDialogOptions {
+  sharedWithCommunity: boolean;
+}
+
+export interface ShareDataSpecificationDialogResponse {
+  sharedWithCommunity: boolean;
+}
+
+@Component({
+  selector: 'mdm-share-data-specification-dialog',
+  templateUrl: './share-data-specification-dialog.component.html',
+  styleUrls: ['./share-data-specification-dialog.component.scss'],
+})
+export class ShareDataSpecificationDialogComponent implements OnInit {
+  initialSharedValue: boolean;
+  dialogCheckboxValue: boolean;
+  checkBoxDisabled: boolean = false;
+
+  constructor(
+    public dialogRef: MatDialogRef<
+      ShareDataSpecificationDialogComponent,
+      ShareDataSpecificationDialogResponse
+    >,
+    @Inject(MAT_DIALOG_DATA)
+    @Optional()
+    private data: ShareDataSpecificationDialogOptions
+  ) {
+    this.initialSharedValue = this.data.sharedWithCommunity;
+    this.dialogCheckboxValue = this.data.sharedWithCommunity;
+  }
+
+  ngOnInit(): void {}
+
+  update() {
+    this.dialogRef.close({
+      sharedWithCommunity: this.dialogCheckboxValue,
+    });
+  }
+
+  close() {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/mauro/data-model.service.ts
+++ b/src/app/mauro/data-model.service.ts
@@ -448,4 +448,30 @@ export class DataModelService {
       .update(id, data, options)
       .pipe(map((response: DataModelDetailResponse) => response.body));
   }
+
+  /**
+   * Marks a {@link DataModel} to be readable by
+   * any authenticated user.
+   *
+   * @param id The id of the {@link DataModel} to update.
+   * @returns an observable containing the updated {@link DataModelDetail}
+   */
+  updateReadByAuthenticated(id: Uuid): Observable<DataModelDetail> {
+    return this.endpoints.dataModel
+      .updateReadByAuthenticated(id)
+      .pipe(map((response: DataModelDetailResponse) => response.body));
+  }
+
+  /**
+   * Marks a {@link DataModel} to not be readable by
+   * all authenticated users.
+   *
+   * @param id The id of the {@link DataModel} to update.
+   * @returns an observable containing the updated {@link DataModelDetail}
+   */
+  removeReadByAuthenticated(id: Uuid): Observable<DataModelDetail> {
+    return this.endpoints.dataModel
+      .removeReadByAuthenticated(id)
+      .pipe(map((response: DataModelDetailResponse) => response.body));
+  }
 }

--- a/src/app/mauro/environment.service.spec.ts
+++ b/src/app/mauro/environment.service.spec.ts
@@ -47,6 +47,6 @@ describe('EnvironmentService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
-    expect(service.apiEndpoint).toBe($ENV.apiEndpoint);
+    expect(service.mauroCoreEndpoint).toBe($ENV.mauroCoreEndpoint);
   });
 });

--- a/src/app/mauro/environment.service.ts
+++ b/src/app/mauro/environment.service.ts
@@ -24,5 +24,5 @@ import { environment } from 'src/environments/environment.prod';
   providedIn: 'root',
 })
 export class EnvironmentService {
-  readonly apiEndpoint?: string = environment?.apiEndpoint;
+  readonly mauroCoreEndpoint?: string = environment?.mauroCoreEndpoint;
 }

--- a/src/app/mauro/plugins/plugin-research.resource.ts
+++ b/src/app/mauro/plugins/plugin-research.resource.ts
@@ -126,4 +126,19 @@ export class MdmPluginResearchResource extends MdmResource {
     const url = `${this.apiEndpoint}/explorer/theme`;
     return this.simpleGet(url, query, options);
   }
+
+  /**
+   * `HTTP GET` - Gets the list of all shared data specifications
+   * excepts those of the current user.
+   *
+   * @param query Optional query parameters, if required.
+   * @param options Optional REST handler parameters, if required.
+   * @returns The result of the `GET` request:
+   *
+   * `200 OK` - will return a list of {@link DataModel}.
+   */
+  listSharedDataSpecifications(query?: QueryParameters, options?: RequestSettings) {
+    const url = `${this.apiEndpoint}/explorer/sharedDataSpecifications`;
+    return this.simpleGet(url, query, options);
+  }
 }

--- a/src/app/mauro/research-plugin.service.ts
+++ b/src/app/mauro/research-plugin.service.ts
@@ -18,7 +18,6 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { Injectable } from '@angular/core';
 import {
-  DataModel,
   DataModelDetail,
   DataModelDetailResponse,
   DataModelIndexResponse,
@@ -27,7 +26,7 @@ import {
   MdmIndexResponse,
   Uuid,
 } from '@maurodatamapper/mdm-resources';
-import { map, Observable, of, switchMap } from 'rxjs';
+import { map, Observable, switchMap } from 'rxjs';
 import { KeyValueIdentifier } from './mauro.types';
 import { MdmEndpointsService } from './mdm-endpoints.service';
 import {
@@ -83,11 +82,12 @@ export class ResearchPluginService {
   }
 
   listSharedDataSpecifications(): Observable<DataSpecification[]> {
-    return this.endpoints.pluginResearch.listSharedDataSpecifications().pipe(
-      switchMap((response: DataModelIndexResponse): Observable<DataModel[]> => {
-        return of(response.body.items); // eslint-disable-line @typescript-eslint/no-non-null-assertion
-      }),
-      map((dataModels: DataModel[]) => dataModels.map(mapToDataSpecification))
-    );
+    return this.endpoints.pluginResearch
+      .listSharedDataSpecifications()
+      .pipe(
+        map((response: DataModelIndexResponse) =>
+          response.body.items.map(mapToDataSpecification)
+        )
+      );
   }
 }

--- a/src/app/mauro/research-plugin.service.ts
+++ b/src/app/mauro/research-plugin.service.ts
@@ -18,8 +18,10 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { Injectable } from '@angular/core';
 import {
+  DataModel,
   DataModelDetail,
   DataModelDetailResponse,
+  DataModelIndexResponse,
   FolderDetail,
   FolderDetailResponse,
   MdmIndexResponse,
@@ -32,6 +34,10 @@ import {
   PluginResearchContactPayload,
   PluginResearchContactResponse,
 } from './plugins/plugin-research.resource';
+import {
+  DataSpecification,
+  mapToDataSpecification,
+} from '../data-explorer/data-explorer.types';
 
 @Injectable({
   providedIn: 'root',
@@ -74,5 +80,14 @@ export class ResearchPluginService {
     return this.endpoints.pluginResearch
       .theme()
       .pipe(map((response: MdmIndexResponse<KeyValueIdentifier>) => response.body.items));
+  }
+
+  listSharedDataSpecifications(): Observable<DataSpecification[]> {
+    return this.endpoints.pluginResearch.listSharedDataSpecifications().pipe(
+      switchMap((response: DataModelIndexResponse): any => {
+        return response.body; // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      }),
+      map((dataModels: DataModel[]) => dataModels.map(mapToDataSpecification))
+    );
   }
 }

--- a/src/app/mauro/research-plugin.service.ts
+++ b/src/app/mauro/research-plugin.service.ts
@@ -27,7 +27,7 @@ import {
   MdmIndexResponse,
   Uuid,
 } from '@maurodatamapper/mdm-resources';
-import { map, Observable, switchMap } from 'rxjs';
+import { map, Observable, of, switchMap } from 'rxjs';
 import { KeyValueIdentifier } from './mauro.types';
 import { MdmEndpointsService } from './mdm-endpoints.service';
 import {
@@ -84,8 +84,8 @@ export class ResearchPluginService {
 
   listSharedDataSpecifications(): Observable<DataSpecification[]> {
     return this.endpoints.pluginResearch.listSharedDataSpecifications().pipe(
-      switchMap((response: DataModelIndexResponse): any => {
-        return response.body; // eslint-disable-line @typescript-eslint/no-non-null-assertion
+      switchMap((response: DataModelIndexResponse): Observable<DataModel[]> => {
+        return of(response.body.items); // eslint-disable-line @typescript-eslint/no-non-null-assertion
       }),
       map((dataModels: DataModel[]) => dataModels.map(mapToDataSpecification))
     );

--- a/src/app/pages/data-element/data-element.component.ts
+++ b/src/app/pages/data-element/data-element.component.ts
@@ -107,6 +107,7 @@ export class DataElementComponent implements OnInit {
           this.dataElement = dataElementDetail;
           this.dataElementDataTypeCasted = this.dataElement?.dataType as DataType;
           this.isBookmarked = isBookmarked;
+          this.dataElementDataTypeCasted = this.dataElement?.dataType as DataType;
           this.dataElementSearchResult = [
             {
               id: dataElementDetail.id ?? '',

--- a/src/app/pages/data-element/data-element.component.ts
+++ b/src/app/pages/data-element/data-element.component.ts
@@ -107,7 +107,6 @@ export class DataElementComponent implements OnInit {
           this.dataElement = dataElementDetail;
           this.dataElementDataTypeCasted = this.dataElement?.dataType as DataType;
           this.isBookmarked = isBookmarked;
-          this.dataElementDataTypeCasted = this.dataElement?.dataType as DataType;
           this.dataElementSearchResult = [
             {
               id: dataElementDetail.id ?? '',

--- a/src/app/pages/my-data-specification-detail/my-data-specification-detail.component.html
+++ b/src/app/pages/my-data-specification-detail/my-data-specification-detail.component.html
@@ -29,7 +29,8 @@ SPDX-License-Identifier: Apache-2.0
     </div>
     <div *ngIf="!currentUserOwnsDataSpec">
       <mdm-back-link
-        routerLink="/templates/community"
+        routerLink="/templates"
+        [queryParams]="{ templateType: 'community' }"
         label="Back to Templates"
       ></mdm-back-link>
     </div>
@@ -106,7 +107,10 @@ SPDX-License-Identifier: Apache-2.0
 
     <div
       class="mdm-my-data-specification__specification-elements"
-      *ngIf="sourceTargetIntersections.dataSpecifications.length > 0"
+      *ngIf="
+        sourceTargetIntersections.dataSpecifications.length > 0 ||
+        !currentUserOwnsDataSpec
+      "
     >
       <mdm-data-schema-row
         *ngFor="let dataSchema of dataSchemas"

--- a/src/app/pages/my-data-specification-detail/my-data-specification-detail.component.html
+++ b/src/app/pages/my-data-specification-detail/my-data-specification-detail.component.html
@@ -36,9 +36,11 @@ SPDX-License-Identifier: Apache-2.0
         [showSubmitButton]="dataSpecification.status === 'unsent'"
         [showCopyButton]="dataSpecification.status === 'submitted'"
         [showEditButton]="dataSpecification.status === 'unsent'"
+        [showShareButton]="true"
         (submitClick)="submitDataSpecification()"
         (copyClick)="copyDataSpecification()"
         (editClick)="editDataSpecification()"
+        (shareClick)="shareDataSpecification()"
       ></mdm-data-specification-row>
     </div>
 

--- a/src/app/pages/my-data-specification-detail/my-data-specification-detail.component.html
+++ b/src/app/pages/my-data-specification-detail/my-data-specification-detail.component.html
@@ -28,7 +28,10 @@ SPDX-License-Identifier: Apache-2.0
       ></mdm-back-link>
     </div>
     <div *ngIf="!currentUserOwnsDataSpec">
-      <mdm-back-link routerLink="/templates" label="Back to Templates"></mdm-back-link>
+      <mdm-back-link
+        routerLink="/templates/community"
+        label="Back to Templates"
+      ></mdm-back-link>
     </div>
     <div *ngIf="state === 'loading'" class="mdm-my-data-specification__progress">
       <mat-progress-bar color="primary" mode="indeterminate"></mat-progress-bar>
@@ -45,7 +48,9 @@ SPDX-License-Identifier: Apache-2.0
         [showEditButton]="
           dataSpecification.status === 'unsent' && currentUserOwnsDataSpec
         "
-        [showShareButton]="currentUserOwnsDataSpec"
+        [showShareButton]="
+          currentUserOwnsDataSpec && dataSpecification.status === 'submitted'
+        "
         (submitClick)="submitDataSpecification()"
         (copyClick)="copyDataSpecification()"
         (editClick)="editDataSpecification()"

--- a/src/app/pages/my-data-specification-detail/my-data-specification-detail.component.html
+++ b/src/app/pages/my-data-specification-detail/my-data-specification-detail.component.html
@@ -21,10 +21,15 @@ SPDX-License-Identifier: Apache-2.0
     <div class="main-row hero">
       <h1>{{ dataSpecification.label }}</h1>
     </div>
-    <mdm-back-link
-      routerLink="/dataSpecifications"
-      label="Back to My Data Specifications"
-    ></mdm-back-link>
+    <div *ngIf="currentUserOwnsDataSpec">
+      <mdm-back-link
+        routerLink="/dataSpecifications"
+        label="Back to My Data Specifications"
+      ></mdm-back-link>
+    </div>
+    <div *ngIf="!currentUserOwnsDataSpec">
+      <mdm-back-link routerLink="/templates" label="Back to Templates"></mdm-back-link>
+    </div>
     <div *ngIf="state === 'loading'" class="mdm-my-data-specification__progress">
       <mat-progress-bar color="primary" mode="indeterminate"></mat-progress-bar>
     </div>
@@ -33,10 +38,14 @@ SPDX-License-Identifier: Apache-2.0
         [dataSpecification]="dataSpecification"
         [showLabel]="false"
         [showStatus]="true"
-        [showSubmitButton]="dataSpecification.status === 'unsent'"
+        [showSubmitButton]="
+          dataSpecification.status === 'unsent' && currentUserOwnsDataSpec
+        "
         [showCopyButton]="dataSpecification.status === 'submitted'"
-        [showEditButton]="dataSpecification.status === 'unsent'"
-        [showShareButton]="true"
+        [showEditButton]="
+          dataSpecification.status === 'unsent' && currentUserOwnsDataSpec
+        "
+        [showShareButton]="currentUserOwnsDataSpec"
         (submitClick)="submitDataSpecification()"
         (copyClick)="copyDataSpecification()"
         (editClick)="editDataSpecification()"
@@ -49,14 +58,18 @@ SPDX-License-Identifier: Apache-2.0
     <mdm-data-query-row
       queryType="cohort"
       [condition]="cohortQuery"
-      [readOnly]="dataSpecification.status === 'submitted' || isEmpty"
+      [readOnly]="
+        dataSpecification.status === 'submitted' || isEmpty || !currentUserOwnsDataSpec
+      "
       createRouterLink="queries/cohort"
       editRouterLink="queries/cohort"
     ></mdm-data-query-row>
     <mdm-data-query-row
       queryType="data"
       [condition]="dataQuery"
-      [readOnly]="dataSpecification.status === 'submitted' || isEmpty"
+      [readOnly]="
+        dataSpecification.status === 'submitted' || isEmpty || !currentUserOwnsDataSpec
+      "
       createRouterLink="queries/data"
       editRouterLink="queries/data"
     ></mdm-data-query-row>
@@ -69,7 +82,7 @@ SPDX-License-Identifier: Apache-2.0
     </p>
 
     <div
-      *ngIf="dataSpecification.status === 'unsent'"
+      *ngIf="dataSpecification.status === 'unsent' && currentUserOwnsDataSpec"
       class="mdm-my-data-specification__specification-elements-selectall"
     >
       <mat-checkbox (change)="onSelectAll()" [checked]="allElementsSelected"
@@ -93,7 +106,7 @@ SPDX-License-Identifier: Apache-2.0
       <mdm-data-schema-row
         *ngFor="let dataSchema of dataSchemas"
         [dataSchema]="dataSchema"
-        [canDelete]="dataSpecification.status === 'unsent'"
+        [canDelete]="dataSpecification.status === 'unsent' && currentUserOwnsDataSpec"
         (deleteItemEvent)="removeItem($event)"
         [suppressViewDataSpecificationsDialogButton]="true"
         (dataSpecificationAddDelete)="handleDataSpecificationElementsChange($event)"

--- a/src/app/pages/my-data-specification-detail/my-data-specification-detail.component.spec.ts
+++ b/src/app/pages/my-data-specification-detail/my-data-specification-detail.component.spec.ts
@@ -66,6 +66,7 @@ import {
   setupTestModuleForComponent,
 } from '../../testing/testing.helpers';
 import { MyDataSpecificationDetailComponent } from './my-data-specification-detail.component';
+import { SecurityService } from 'src/app/security/security.service';
 
 describe('MyDataSpecificationsComponent', () => {
   let harness: ComponentHarness<MyDataSpecificationDetailComponent>;
@@ -124,6 +125,10 @@ describe('MyDataSpecificationsComponent', () => {
           provide: ActivatedRoute,
           useValue: activatedRoute,
         },
+        {
+          provide: SecurityService,
+          useValue: securityStub,
+        },
       ],
     });
   });
@@ -133,9 +138,14 @@ describe('MyDataSpecificationsComponent', () => {
     label: 'data specification 1',
     domainType: CatalogueItemDomainType.DataModel,
     status: 'unsent',
+    author: 'Test User',
   };
 
-  const user = { email: 'test@test.com' } as UserDetails;
+  const user = {
+    email: 'test@test.com',
+    firstName: 'Test',
+    lastName: 'User',
+  } as UserDetails;
 
   const mockSignedInUser = () => {
     securityStub.getSignedInUser.mockReturnValueOnce(user);

--- a/src/app/pages/my-data-specification-detail/my-data-specification-detail.component.ts
+++ b/src/app/pages/my-data-specification-detail/my-data-specification-detail.component.ts
@@ -66,7 +66,7 @@ import {
 import { DataSchemaService } from '../../data-explorer/data-schema.service';
 import { ResearchPluginService } from '../../mauro/research-plugin.service';
 import { DataSpecificationElementAddDeleteEvent } from '../../shared/data-element-in-data-specification/data-element-in-data-specification.component';
-import { ShareDataSpecificationDialogResponse } from 'src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component';
+import { ShareDataSpecificationDialogInputOutput } from 'src/app/data-explorer/share-data-specification-dialog/share-data-specification-dialog.component';
 import { DataModelService } from 'src/app/mauro/data-model.service';
 import { SecurityService } from '../../security/security.service';
 
@@ -390,7 +390,7 @@ export class MyDataSpecificationDetailComponent implements OnInit, OnDestroy {
 
     this.dataSpecificationService
       .shareWithDialog(this.dataSpecification.readableByAuthenticatedUsers as boolean)
-      .subscribe((response: ShareDataSpecificationDialogResponse) => {
+      .subscribe((response: ShareDataSpecificationDialogInputOutput) => {
         if (!this.dataSpecification || !this.dataSpecification.id) {
           return;
         }

--- a/src/app/pages/my-data-specification-detail/my-data-specification-detail.component.ts
+++ b/src/app/pages/my-data-specification-detail/my-data-specification-detail.component.ts
@@ -118,15 +118,15 @@ export class MyDataSpecificationDetailComponent implements OnInit, OnDestroy {
   // remove selected button is disabled.
   anyElementSelected = false;
 
-  /**
-   * Signal to attach to subscriptions to trigger when they should be unsubscribed.
-   */
-  private unsubscribe$ = new Subject<void>();
-
   // Whether the creator of the data spec
   // is the current user or not.
   // A user that is not the owner cannot edit
   currentUserOwnsDataSpec = false;
+
+  /**
+   * Signal to attach to subscriptions to trigger when they should be unsubscribed.
+   */
+  private unsubscribe$ = new Subject<void>();
 
   constructor(
     private route: ActivatedRoute,
@@ -389,31 +389,37 @@ export class MyDataSpecificationDetailComponent implements OnInit, OnDestroy {
     }
 
     this.dataSpecificationService
-      .shareWithDialog(this.dataSpecification.readableByAuthenticatedUsers)
+      .shareWithDialog(this.dataSpecification.readableByAuthenticatedUsers as boolean)
       .subscribe((response: ShareDataSpecificationDialogResponse) => {
         if (!this.dataSpecification || !this.dataSpecification.id) {
           return;
         }
 
         if (
-          this.dataSpecification.readableByAuthenticatedUsers !=
+          this.dataSpecification.readableByAuthenticatedUsers !==
           response.sharedWithCommunity
         ) {
           // Shared
           if (response.sharedWithCommunity) {
             this.dataModels
               .updateReadByAuthenticated(this.dataSpecification.id)
-              .subscribe((response) => {
-                this.dataSpecification!.readableByAuthenticatedUsers =
-                  response.readableByAuthenticatedUsers;
+              .subscribe((updatedDataSpec) => {
+                if (!this.dataSpecification) {
+                  return;
+                }
+                this.dataSpecification.readableByAuthenticatedUsers =
+                  updatedDataSpec.readableByAuthenticatedUsers;
                 this.toastr.success('Data specification shared with the community');
               });
           } else {
             this.dataModels
               .removeReadByAuthenticated(this.dataSpecification.id)
-              .subscribe((response) => {
-                this.dataSpecification!.readableByAuthenticatedUsers =
-                  response.readableByAuthenticatedUsers;
+              .subscribe((updatedDataSpec) => {
+                if (!this.dataSpecification) {
+                  return;
+                }
+                this.dataSpecification.readableByAuthenticatedUsers =
+                  updatedDataSpec.readableByAuthenticatedUsers;
                 this.toastr.success('Data specification not shared anymore');
               });
           }

--- a/src/app/pages/my-data-specification-detail/my-data-specification-detail.component.ts
+++ b/src/app/pages/my-data-specification-detail/my-data-specification-detail.component.ts
@@ -353,7 +353,20 @@ export class MyDataSpecificationDetailComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.dataSpecificationService.forkWithDialogs(this.dataSpecification).subscribe();
+    this.dataSpecificationService
+      .getDataSpecificationFolder()
+      .pipe(
+        switchMap((dataSpecificationFolder) => {
+          if (!this.dataSpecification) {
+            return EMPTY;
+          }
+
+          return this.dataSpecificationService.forkWithDialogs(this.dataSpecification, {
+            targetFolder: dataSpecificationFolder,
+          });
+        })
+      )
+      .subscribe();
   }
 
   /**

--- a/src/app/pages/my-data-specifications/my-data-specifications.component.ts
+++ b/src/app/pages/my-data-specifications/my-data-specifications.component.ts
@@ -96,7 +96,6 @@ export class MyDataSpecificationsComponent implements OnInit {
     if (!user) {
       return throwError(() => new Error('Cannot find user'));
     }
-    console.log(user.dataSpecificationFolder);
     return this.dataSpecification.list().pipe(
       catchError(() => {
         this.toastr.error('There was a problem finding your data specifications.');

--- a/src/app/pages/my-data-specifications/my-data-specifications.component.ts
+++ b/src/app/pages/my-data-specifications/my-data-specifications.component.ts
@@ -96,7 +96,7 @@ export class MyDataSpecificationsComponent implements OnInit {
     if (!user) {
       return throwError(() => new Error('Cannot find user'));
     }
-
+    console.log(user.dataSpecificationFolder);
     return this.dataSpecification.list().pipe(
       catchError(() => {
         this.toastr.error('There was a problem finding your data specifications.');

--- a/src/app/pages/pages.routes.ts
+++ b/src/app/pages/pages.routes.ts
@@ -178,6 +178,11 @@ export const routes: Route[] = [
     canActivate: [AuthorizedGuard],
   },
   {
+    path: 'templates/:templateType',
+    component: TemplateDataSpecificationsComponent,
+    canActivate: [AuthorizedGuard],
+  },
+  {
     path: 'templates/:dataSpecificationId',
     component: TemplateDataSpecificationDetailComponent,
     canActivate: [AuthorizedGuard],

--- a/src/app/pages/pages.routes.ts
+++ b/src/app/pages/pages.routes.ts
@@ -178,11 +178,6 @@ export const routes: Route[] = [
     canActivate: [AuthorizedGuard],
   },
   {
-    path: 'templates/:templateType',
-    component: TemplateDataSpecificationsComponent,
-    canActivate: [AuthorizedGuard],
-  },
-  {
     path: 'templates/:dataSpecificationId',
     component: TemplateDataSpecificationDetailComponent,
     canActivate: [AuthorizedGuard],

--- a/src/app/pages/template-data-specification-detail/template-data-specification-detail.component.spec.ts
+++ b/src/app/pages/template-data-specification-detail/template-data-specification-detail.component.spec.ts
@@ -40,6 +40,8 @@ import {
 } from '../../testing/testing.helpers';
 
 import { TemplateDataSpecificationDetailComponent } from './template-data-specification-detail.component';
+import { SecurityService } from 'src/app/security/security.service';
+import { createSecurityServiceStub } from 'src/app/testing/stubs/security.stub';
 
 describe('TemplateDataSpecificationDetailComponent', () => {
   let harness: ComponentHarness<TemplateDataSpecificationDetailComponent>;
@@ -48,6 +50,7 @@ describe('TemplateDataSpecificationDetailComponent', () => {
   const dataSchemaStub = createDataSchemaServiceStub();
   const toastrStub = createToastrServiceStub();
   const mdmResourcesConfiguration = new MdmResourcesConfiguration();
+  const securityStub = createSecurityServiceStub();
 
   const templateId = '123';
   const activatedRoute: ActivatedRoute = {
@@ -80,6 +83,10 @@ describe('TemplateDataSpecificationDetailComponent', () => {
           {
             provide: MdmResourcesConfiguration,
             useValue: mdmResourcesConfiguration,
+          },
+          {
+            provide: SecurityService,
+            useValue: securityStub,
           },
         ],
       }

--- a/src/app/pages/template-data-specifications/template-data-specifications.component.html
+++ b/src/app/pages/template-data-specifications/template-data-specifications.component.html
@@ -37,7 +37,25 @@ SPDX-License-Identifier: Apache-2.0
       [options]="sortByOptions"
       (valueChange)="selectSortBy($event)"
     ></mdm-sort-by>
+    <mdm-sort-by
+      [value]="contentToDisplay"
+      [options]="contentToDisplayOptions"
+      (valueChange)="selectContentToDisplay($event)"
+    ></mdm-sort-by>
   </div>
+  <hr />
+  <div *ngFor="let dataSpecification of sharedDataSpecifications">
+    <div class="col">
+      <mdm-data-specification-row
+        [dataSpecification]="dataSpecification"
+        [showStatus]="false"
+        [detailsRouterLink]="['/dataSpecification', dataSpecification.id]"
+        [showCopyButton]="true"
+        (copyClick)="copy(dataSpecification)"
+      ></mdm-data-specification-row>
+    </div>
+  </div>
+  <hr />
   <div *ngIf="state === 'loading'" class="mdm-template-data-specifications__progress">
     <mat-progress-bar color="primary" mode="indeterminate"></mat-progress-bar>
   </div>

--- a/src/app/pages/template-data-specifications/template-data-specifications.component.html
+++ b/src/app/pages/template-data-specifications/template-data-specifications.component.html
@@ -31,58 +31,84 @@ SPDX-License-Identifier: Apache-2.0
     </div>
   </div>
   <div class="mdm-template-data-specifications__sort-row">
-    <span class="spacer"></span>
-    <mdm-sort-by
-      [value]="sortBy"
-      [options]="sortByOptions"
-      (valueChange)="selectSortBy($event)"
-    ></mdm-sort-by>
-    <mdm-sort-by
-      [value]="contentToDisplay"
-      [options]="contentToDisplayOptions"
-      (valueChange)="selectContentToDisplay($event)"
-    ></mdm-sort-by>
-  </div>
-  <hr />
-  <div *ngFor="let dataSpecification of sharedDataSpecifications">
-    <div class="col">
-      <mdm-data-specification-row
-        [dataSpecification]="dataSpecification"
-        [showStatus]="false"
-        [detailsRouterLink]="['/dataSpecification', dataSpecification.id]"
-        [showCopyButton]="true"
-        (copyClick)="copy(dataSpecification)"
-      ></mdm-data-specification-row>
+    <div class="col-md-8">
+      <!-- EMTPY SPACE -->
+    </div>
+    <div class="vertically-aligned col-md-4">
+      <mdm-sort-by
+        [value]="sortBy"
+        [options]="sortByOptions"
+        (valueChange)="selectSortBy($event)"
+      ></mdm-sort-by>
+      <mdm-filter-by
+        [value]="contentToDisplay"
+        [options]="contentToDisplayOptions"
+        (valueChange)="selectContentToDisplay($event)"
+      ></mdm-filter-by>
     </div>
   </div>
-  <hr />
+
   <div *ngIf="state === 'loading'" class="mdm-template-data-specifications__progress">
     <mat-progress-bar color="primary" mode="indeterminate"></mat-progress-bar>
   </div>
-  <div
-    *ngIf="!templateDataSpecifications || templateDataSpecifications.length === 0"
-    class="row"
-  >
-    <p class="text-center">
-      We currently have no data specification templates but are working on adding some
-      soon. In the meantime, you are able to
-      <a routerLink="/search">search</a> or <a routerLink="/browse">browse</a> our
-      catalogue and start creating your own research data specifications from scratch.
-    </p>
+
+  <div *ngIf="contentToDisplay.value === 'Templates'">
+    <div
+      *ngIf="!templateDataSpecifications || templateDataSpecifications.length === 0"
+      class="row"
+    >
+      <p class="text-center">
+        We currently have no data specification templates but are working on adding some
+        soon. In the meantime, you are able to
+        <a routerLink="/search">search</a> or <a routerLink="/browse">browse</a> our
+        catalogue and start creating your own research data specifications from scratch.
+      </p>
+    </div>
+    <div
+      *ngIf="templateDataSpecifications && templateDataSpecifications.length > 0"
+      class="row"
+    >
+      <div *ngFor="let dataSpecification of templateDataSpecifications">
+        <div class="col">
+          <mdm-data-specification-row
+            [dataSpecification]="dataSpecification"
+            [showStatus]="false"
+            [detailsRouterLink]="['/templates', dataSpecification.id]"
+            [showCopyButton]="true"
+            (copyClick)="copy(dataSpecification)"
+          ></mdm-data-specification-row>
+        </div>
+      </div>
+    </div>
   </div>
-  <div
-    *ngIf="templateDataSpecifications && templateDataSpecifications.length > 0"
-    class="row"
-  >
-    <div *ngFor="let dataSpecification of templateDataSpecifications">
-      <div class="col">
-        <mdm-data-specification-row
-          [dataSpecification]="dataSpecification"
-          [showStatus]="false"
-          [detailsRouterLink]="['/templates', dataSpecification.id]"
-          [showCopyButton]="true"
-          (copyClick)="copy(dataSpecification)"
-        ></mdm-data-specification-row>
+
+  <div *ngIf="contentToDisplay.value === 'Community'">
+    <div
+      *ngIf="!sharedDataSpecifications || sharedDataSpecifications.length === 0"
+      class="row"
+    >
+      <p class="text-center">
+        Currently there are no shared specifications. You are able to
+        <a routerLink="/search">search</a> or <a routerLink="/browse">browse</a> our
+        catalogue and start creating your own research data specifications from scratch.
+        Then, you can share them with the community.
+      </p>
+    </div>
+
+    <div
+      *ngIf="sharedDataSpecifications && sharedDataSpecifications.length > 0"
+      class="row"
+    >
+      <div *ngFor="let dataSpecification of sharedDataSpecifications">
+        <div class="col">
+          <mdm-data-specification-row
+            [dataSpecification]="dataSpecification"
+            [showStatus]="false"
+            [detailsRouterLink]="['/dataSpecifications', dataSpecification.id]"
+            [showCopyButton]="true"
+            (copyClick)="copy(dataSpecification)"
+          ></mdm-data-specification-row>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/pages/template-data-specifications/template-data-specifications.component.spec.ts
+++ b/src/app/pages/template-data-specifications/template-data-specifications.component.spec.ts
@@ -46,9 +46,7 @@ describe('TemplateDataSpecificationsComponent', () => {
   const mdmResourcesConfiguration = new MdmResourcesConfiguration();
 
   const activatedRoute: ActivatedRoute = {
-    params: of({
-      templateType: '',
-    }),
+    queryParams: of({}),
   } as unknown as ActivatedRoute;
 
   beforeEach(async () => {

--- a/src/app/pages/template-data-specifications/template-data-specifications.component.spec.ts
+++ b/src/app/pages/template-data-specifications/template-data-specifications.component.spec.ts
@@ -35,6 +35,7 @@ import {
 import { TemplateDataSpecificationsComponent } from './template-data-specifications.component';
 import { SecurityService } from 'src/app/security/security.service';
 import { createSecurityServiceStub } from 'src/app/testing/stubs/security.stub';
+import { ActivatedRoute } from '@angular/router';
 
 describe('TemplateDataSpecificationsComponent', () => {
   let harness: ComponentHarness<TemplateDataSpecificationsComponent>;
@@ -43,6 +44,12 @@ describe('TemplateDataSpecificationsComponent', () => {
   const toastrStub = createToastrServiceStub();
   const securityStub = createSecurityServiceStub();
   const mdmResourcesConfiguration = new MdmResourcesConfiguration();
+
+  const activatedRoute: ActivatedRoute = {
+    params: of({
+      templateType: '',
+    }),
+  } as unknown as ActivatedRoute;
 
   beforeEach(async () => {
     harness = await setupTestModuleForComponent(TemplateDataSpecificationsComponent, {
@@ -62,6 +69,10 @@ describe('TemplateDataSpecificationsComponent', () => {
         {
           provide: MdmResourcesConfiguration,
           useValue: mdmResourcesConfiguration,
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: activatedRoute,
         },
       ],
     });

--- a/src/app/pages/template-data-specifications/template-data-specifications.component.spec.ts
+++ b/src/app/pages/template-data-specifications/template-data-specifications.component.spec.ts
@@ -16,7 +16,11 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { CatalogueItemDomainType, FolderDetail } from '@maurodatamapper/mdm-resources';
+import {
+  CatalogueItemDomainType,
+  FolderDetail,
+  MdmResourcesConfiguration,
+} from '@maurodatamapper/mdm-resources';
 import { ToastrService } from 'ngx-toastr';
 import { of, throwError } from 'rxjs';
 import { DataSpecification } from '../../data-explorer/data-explorer.types';
@@ -29,12 +33,16 @@ import {
 } from '../../testing/testing.helpers';
 
 import { TemplateDataSpecificationsComponent } from './template-data-specifications.component';
+import { SecurityService } from 'src/app/security/security.service';
+import { createSecurityServiceStub } from 'src/app/testing/stubs/security.stub';
 
 describe('TemplateDataSpecificationsComponent', () => {
   let harness: ComponentHarness<TemplateDataSpecificationsComponent>;
 
   const dataSpecificationStub = createDataSpecificationServiceStub();
   const toastrStub = createToastrServiceStub();
+  const securityStub = createSecurityServiceStub();
+  const mdmResourcesConfiguration = new MdmResourcesConfiguration();
 
   beforeEach(async () => {
     harness = await setupTestModuleForComponent(TemplateDataSpecificationsComponent, {
@@ -46,6 +54,14 @@ describe('TemplateDataSpecificationsComponent', () => {
         {
           provide: ToastrService,
           useValue: toastrStub,
+        },
+        {
+          provide: SecurityService,
+          useValue: securityStub,
+        },
+        {
+          provide: MdmResourcesConfiguration,
+          useValue: mdmResourcesConfiguration,
         },
       ],
     });

--- a/src/app/pages/template-data-specifications/template-data-specifications.component.ts
+++ b/src/app/pages/template-data-specifications/template-data-specifications.component.ts
@@ -25,6 +25,7 @@ import { SortByOption } from '../../data-explorer/sort-by/sort-by.component';
 import { FilterByOption } from '../../data-explorer/filter-by/filter-by.component';
 import { Sort } from '../../mauro/sort.type';
 import { ResearchPluginService } from '../../mauro/research-plugin.service';
+import { ActivatedRoute } from '@angular/router';
 
 /**
  * These options must be of the form '{propertyToSortBy}-{order}' where propertyToSortBy
@@ -63,18 +64,24 @@ export class TemplateDataSpecificationsComponent implements OnInit {
   constructor(
     private dataSpecification: DataSpecificationService,
     private toastr: ToastrService,
-    private researchPlugin: ResearchPluginService
+    private researchPlugin: ResearchPluginService,
+    private route: ActivatedRoute
   ) {}
 
   ngOnInit(): void {
     this.state = 'loading';
 
-    this.dataSpecification
-      .listTemplates()
+    this.route.params
       .pipe(
+        switchMap((params) => {
+          if (params.templateType === 'community') {
+            this.contentToDisplay = this.contentToDisplayOptions[1];
+          }
+
+          return this.dataSpecification.listTemplates();
+        }),
         switchMap((templates) => {
           this.templateDataSpecifications = templates;
-          this.filterAndSortDataSpecifications();
           return this.researchPlugin.listSharedDataSpecifications();
         }),
         catchError(() => {
@@ -85,6 +92,8 @@ export class TemplateDataSpecificationsComponent implements OnInit {
       )
       .subscribe((sharedDataSpecs) => {
         this.sharedDataSpecifications = sharedDataSpecs;
+        this.filterAndSortDataSpecifications();
+        this.state = 'idle';
       });
   }
 

--- a/src/app/pages/template-data-specifications/template-data-specifications.component.ts
+++ b/src/app/pages/template-data-specifications/template-data-specifications.component.ts
@@ -23,6 +23,7 @@ import { DataSpecification } from '../../data-explorer/data-explorer.types';
 import { DataSpecificationService } from '../../data-explorer/data-specification.service';
 import { SortByOption } from '../../data-explorer/sort-by/sort-by.component';
 import { Sort } from '../../mauro/sort.type';
+import { ResearchPluginService } from '../../mauro/research-plugin.service';
 
 /**
  * These options must be of the form '{propertyToSortBy}-{order}' where propertyToSortBy
@@ -39,6 +40,9 @@ export type TemplateDataSpecificationSortByOption = 'label-asc' | 'label-desc';
 export class TemplateDataSpecificationsComponent implements OnInit {
   templateDataSpecifications: DataSpecification[] = [];
   filteredDataSpecifications: DataSpecification[] = [];
+  sharedDataSpecifications: DataSpecification[] = [];
+  communityDataSpecifications: DataSpecification[] = [];
+
   state: 'idle' | 'loading' = 'idle';
 
   sortByOptions: SortByOption[] = [
@@ -48,13 +52,25 @@ export class TemplateDataSpecificationsComponent implements OnInit {
   sortByDefaultOption: SortByOption = this.sortByOptions[0];
   sortBy?: SortByOption;
 
+  contentToDisplayOptions: SortByOption[] = [
+    { value: 'Templates', displayName: 'Templates' },
+    { value: 'Community', displayName: 'Community' },
+  ];
+  contentToDisplayDefaultOption = this.contentToDisplayOptions[0];
+  contentToDisplay: SortByOption = this.contentToDisplayDefaultOption;
+
   constructor(
     private dataSpecification: DataSpecificationService,
-    private toastr: ToastrService
+    private toastr: ToastrService,
+    private researchPlugin: ResearchPluginService
   ) {}
 
   ngOnInit(): void {
     this.state = 'loading';
+
+    this.researchPlugin.listSharedDataSpecifications().subscribe((response) => {
+      this.sharedDataSpecifications = response;
+    });
 
     this.dataSpecification
       .listTemplates()
@@ -86,6 +102,10 @@ export class TemplateDataSpecificationsComponent implements OnInit {
         )
       )
       .subscribe();
+  }
+
+  selectContentToDisplay(value: SortByOption) {
+    this.contentToDisplay = value;
   }
 
   private filterAndSortDataSpecifications(sortBy?: SortByOption) {

--- a/src/app/pages/template-data-specifications/template-data-specifications.component.ts
+++ b/src/app/pages/template-data-specifications/template-data-specifications.component.ts
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { Component, OnInit } from '@angular/core';
 import { ToastrService } from 'ngx-toastr';
-import { catchError, EMPTY, finalize, map, switchMap } from 'rxjs';
+import { catchError, EMPTY, finalize, switchMap } from 'rxjs';
 import { DataSpecification } from '../../data-explorer/data-explorer.types';
 import { DataSpecificationService } from '../../data-explorer/data-specification.service';
 import { SortByOption } from '../../data-explorer/sort-by/sort-by.component';

--- a/src/app/pages/template-data-specifications/template-data-specifications.component.ts
+++ b/src/app/pages/template-data-specifications/template-data-specifications.component.ts
@@ -71,7 +71,7 @@ export class TemplateDataSpecificationsComponent implements OnInit {
   ngOnInit(): void {
     this.state = 'loading';
 
-    this.route.params
+    this.route.queryParams
       .pipe(
         switchMap((params) => {
           if (params.templateType === 'community') {

--- a/src/app/secure-data-environment/endpoints/endpoints.dictionary.ts
+++ b/src/app/secure-data-environment/endpoints/endpoints.dictionary.ts
@@ -1,0 +1,26 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+export enum SdeApiEndPoints {
+  OrganisationList = '/organisation/list',
+  OrganisationGet = '/organisation/get?',
+  OrganisationMemberGet = '/organisation_member/get?',
+  OrganisationMemberList = '/organisation_member/list?',
+  AdminUserGet = '/user/admin/get?',
+  ResearchUserGet = '/user/research/get?',
+}

--- a/src/app/secure-data-environment/endpoints/organisation.endpoints.ts
+++ b/src/app/secure-data-environment/endpoints/organisation.endpoints.ts
@@ -35,12 +35,6 @@ export class OrganisationEndpoints {
     );
   }
 
-  getOrganisationMember(organisationMemberId: Uuid): Observable<OrganisationMember[]> {
-    return this.sdeRestHandler.get<OrganisationMember>(
-      `${SdeApiEndPoints.OrganisationMemberGet}${organisationMemberId}`
-    );
-  }
-
   listOrganisationMembers(organisationId: Uuid): Observable<OrganisationMember[]> {
     return this.sdeRestHandler.get<OrganisationMember[]>(
       `${SdeApiEndPoints.OrganisationMemberList}${organisationId}`

--- a/src/app/secure-data-environment/endpoints/organisation.endpoints.ts
+++ b/src/app/secure-data-environment/endpoints/organisation.endpoints.ts
@@ -1,0 +1,49 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Organisation, OrganisationMember } from '../resources/organisation.resources';
+import { Observable } from 'rxjs';
+import { ISdeRestHandler } from '../sde-rest-handler.interface';
+import { Uuid } from '@maurodatamapper/mdm-resources';
+import { SdeApiEndPoints } from './endpoints.dictionary';
+
+export class OrganisationEndpoints {
+  constructor(private sdeRestHandler: ISdeRestHandler) {}
+
+  listOrganisations(): Observable<Organisation[]> {
+    return this.sdeRestHandler.get<Organisation[]>(SdeApiEndPoints.OrganisationList);
+  }
+
+  getOrganisation(organisationId: Uuid): Observable<Organisation> {
+    return this.sdeRestHandler.get<Organisation>(
+      `${SdeApiEndPoints.OrganisationGet}${organisationId}`
+    );
+  }
+
+  getOrganisationMember(organisationMemberId: Uuid): Observable<OrganisationMember[]> {
+    return this.sdeRestHandler.get<OrganisationMember>(
+      `${SdeApiEndPoints.OrganisationMemberGet}${organisationMemberId}`
+    );
+  }
+
+  listOrganisationMembers(organisationId: Uuid): Observable<OrganisationMember[]> {
+    return this.sdeRestHandler.get<OrganisationMember[]>(
+      `${SdeApiEndPoints.OrganisationMemberList}${organisationId}`
+    );
+  }
+}

--- a/src/app/secure-data-environment/endpoints/user.endpoints.ts
+++ b/src/app/secure-data-environment/endpoints/user.endpoints.ts
@@ -1,0 +1,37 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Observable } from 'rxjs';
+import { ISdeRestHandler } from '../sde-rest-handler.interface';
+import { Uuid } from '@maurodatamapper/mdm-resources';
+import { SdeApiEndPoints } from './endpoints.dictionary';
+import { AdminUser, ResearchUser } from '../resources/users.resources';
+
+export class UserEndpoints {
+  constructor(private sdeRestHandler: ISdeRestHandler) {}
+
+  getAdminUser(userId: Uuid): Observable<AdminUser> {
+    return this.sdeRestHandler.get<AdminUser>(`${SdeApiEndPoints.AdminUserGet}${userId}`);
+  }
+
+  getResearchUser(userId: Uuid): Observable<ResearchUser> {
+    return this.sdeRestHandler.get<ResearchUser>(
+      `${SdeApiEndPoints.ResearchUserGet}${userId}`
+    );
+  }
+}

--- a/src/app/secure-data-environment/fake/fake-resources.ts
+++ b/src/app/secure-data-environment/fake/fake-resources.ts
@@ -1,0 +1,119 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Injectable } from '@angular/core';
+import { Organisation, OrganisationMember } from '../resources/organisation.resources';
+import { AdminUser, ResearchUser } from '../resources/users.resources';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FakeResources {
+  adminUsers: AdminUser[] = [
+    {
+      id: '15eaf2b0-833a-434a-ad3e-57de2f4b0885',
+      createdAt: new Date('2023-04-25T00:00:00.000Z'),
+      email: 'admin1@test.com',
+      mauroCoreUser: 'coreUser (admin1@test.com)',
+      isDeleted: false,
+      oidcIssuingAuthority: 'Issuing Authority (admin1@test.com)',
+      oidcSubject: 'Subject (admin1@test.com)',
+    },
+  ];
+
+  researchUsers: ResearchUser[] = [
+    {
+      id: '93f4e049-5105-42f8-aaa3-1925a0f52561',
+      createdAt: new Date('2023-04-25T00:00:00.000Z'),
+      email: 'researcher1@test.com',
+      mauroCoreUser: 'coreUser (researcher1@test.com)',
+      isDeleted: false,
+      oidcIssuingAuthority: 'Issuing Authority (researcher1@test.com)',
+      oidcSubject: 'Subject (researcher1@test.com)',
+    },
+    {
+      id: 'a84114f2-41ab-41e4-a88a-08ec0d3976fc',
+      createdAt: new Date('2023-04-25T00:00:00.000Z'),
+      email: 'researcher2@test.com',
+      mauroCoreUser: 'coreUser (researcher2@test.com)',
+      isDeleted: false,
+      oidcIssuingAuthority: 'Issuing Authority (researcher2@test.com)',
+      oidcSubject: 'Subject (researcher2@test.com)',
+    },
+    {
+      id: '76062aa2-a67e-4a76-88bb-e63c878606ee',
+      createdAt: new Date('2023-04-25T00:00:00.000Z'),
+      email: 'researcher3@test.com',
+      mauroCoreUser: 'coreUser (researcher3@test.com)',
+      isDeleted: false,
+      oidcIssuingAuthority: 'Issuing Authority (researcher3@test.com)',
+      oidcSubject: 'Subject (researcher3@test.com)',
+    },
+  ];
+
+  organisations: Organisation[] = [
+    {
+      id: 'e4e49288-3c0a-4b98-a387-2a813c1bd7fa',
+      createdBy: this.adminUsers[0].id,
+      createdAt: new Date('2023-04-28T00:00:00.000Z'),
+      name: 'Fake Org 1',
+      description: 'A fake organisation for development (Fake Org 1)',
+      mauroCoreGroup: 'Mauro core group (Fake Org 1)',
+      isDeleted: false,
+    },
+    {
+      id: '441d4474-f92c-4152-bd4a-17ce04b1a20d',
+      createdBy: this.adminUsers[0].id,
+      createdAt: new Date('2023-04-28T00:00:00.000Z'),
+      name: 'Fake Org 2',
+      description: 'A fake organisation for development (Fake Org 2)',
+      mauroCoreGroup: 'Mauro core group (Fake Org 2)',
+      isDeleted: false,
+    },
+    {
+      id: '6d6bd8c3-daa3-4a7c-b9c2-6d1f0893705b',
+      createdBy: this.adminUsers[0].id,
+      createdAt: new Date('2023-04-28T00:00:00.000Z'),
+      name: 'Fake Org 3',
+      description: 'A fake organisation for development (Fake Org 3)',
+      mauroCoreGroup: 'Mauro core group (Fake Org 3)',
+      isDeleted: false,
+    },
+  ];
+
+  organisationMembers: OrganisationMember[] = [
+    {
+      id: '5be65c1e-d937-46da-a46c-926d5664dcb6',
+      createdAt: new Date('2023-04-25T00:00:00.000Z'),
+      createdBy: this.adminUsers[0].id,
+      organisationId: this.organisations[0].id,
+      userId: this.researchUsers[0].id,
+      role: 'To be done',
+      endDate: new Date('2023-04-30T00:00:00.000Z'),
+    },
+    {
+      id: '99ea18c4-6057-4381-bb6c-405165190a90',
+      createdAt: new Date('2023-04-25T00:00:00.000Z'),
+      createdBy: this.adminUsers[0].id,
+      organisationId: this.organisations[0].id,
+      userId: this.researchUsers[1].id,
+      role: 'To be done',
+      endDate: new Date('2023-04-30T00:00:00.000Z'),
+    },
+  ];
+}

--- a/src/app/secure-data-environment/fake/fake-sde-rest-handler.ts
+++ b/src/app/secure-data-environment/fake/fake-sde-rest-handler.ts
@@ -36,8 +36,6 @@ export class FakeSdeRestHandler implements ISdeRestHandler {
       return of(this.getOrganisationList());
     } else if (url.startsWith(SdeApiEndPoints.OrganisationGet)) {
       return of(this.getOrganisation(url));
-    } else if (url.startsWith(SdeApiEndPoints.OrganisationMemberGet)) {
-      return of(this.getOrganisationMember(url));
     } else if (url.startsWith(SdeApiEndPoints.OrganisationMemberList)) {
       return of(this.getOrganisationMemberList(url));
     } else if (url.startsWith(SdeApiEndPoints.AdminUserGet)) {

--- a/src/app/secure-data-environment/fake/fake-sde-rest-handler.ts
+++ b/src/app/secure-data-environment/fake/fake-sde-rest-handler.ts
@@ -1,0 +1,110 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Injectable } from '@angular/core';
+import { ISdeRestHandler } from '../sde-rest-handler.interface';
+import { Organisation, OrganisationMember } from '../resources/organisation.resources';
+import { SdeApiEndPoints } from '../endpoints/endpoints.dictionary';
+import { of } from 'rxjs';
+import { AdminUser, ResearchUser } from '../resources/users.resources';
+import { Uuid } from '@maurodatamapper/mdm-resources';
+import { FakeResources } from './fake-resources';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FakeSdeRestHandler implements ISdeRestHandler {
+  constructor(private fakeResources: FakeResources) {}
+
+  get(url: string): any {
+    if (url === SdeApiEndPoints.OrganisationList) {
+      return of(this.getOrganisationList());
+    } else if (url.startsWith(SdeApiEndPoints.OrganisationGet)) {
+      return of(this.getOrganisation(url));
+    } else if (url.startsWith(SdeApiEndPoints.OrganisationMemberGet)) {
+      return of(this.getOrganisationMember(url));
+    } else if (url.startsWith(SdeApiEndPoints.OrganisationMemberList)) {
+      return of(this.getOrganisationMemberList(url));
+    } else if (url.startsWith(SdeApiEndPoints.AdminUserGet)) {
+      return of(this.getAdminUser(url));
+    } else if (url.startsWith(SdeApiEndPoints.ResearchUserGet)) {
+      return of(this.getResearchUser(url));
+    }
+  }
+
+  private getIdFromUrl(url: string) {
+    const splitUrl = url.split('?');
+    if (splitUrl.length === 2) {
+      return splitUrl[1];
+    }
+    throw new Error('Unable to find id in url string');
+  }
+
+  private getOrganisation(url: string): Organisation {
+    const id: Uuid = this.getIdFromUrl(url);
+    const organisation = this.fakeResources.organisations.find((org) => org.id === id);
+    if (organisation == null) {
+      throw new Error('Organisation not found');
+    }
+    return organisation;
+  }
+
+  private getOrganisationList(): Organisation[] {
+    return this.fakeResources.organisations;
+  }
+
+  private getOrganisationMember(url: string): OrganisationMember {
+    const id: Uuid = this.getIdFromUrl(url);
+    const organisationMember = this.fakeResources.organisationMembers.find(
+      (orgMember) => orgMember.id === id
+    );
+    if (organisationMember == null) {
+      throw new Error('Organisation Member not found');
+    }
+    return organisationMember;
+  }
+
+  private getOrganisationMemberList(url: string): OrganisationMember[] {
+    const id: Uuid = this.getIdFromUrl(url);
+    const organisationMembers = this.fakeResources.organisationMembers.filter(
+      (orgMember) => orgMember.organisationId === id
+    );
+    if (organisationMembers == null) {
+      throw new Error('Organisation Members not found');
+    }
+    return organisationMembers;
+  }
+
+  private getAdminUser(url: string): AdminUser {
+    const id: Uuid = this.getIdFromUrl(url);
+    const adminUser = this.fakeResources.adminUsers.find((user) => user.id === id);
+    if (adminUser == null) {
+      throw new Error('Admin user not found');
+    }
+    return adminUser;
+  }
+
+  private getResearchUser(url: string): ResearchUser {
+    const id: Uuid = this.getIdFromUrl(url);
+    const researchUser = this.fakeResources.researchUsers.find((user) => user.id === id);
+    if (researchUser == null) {
+      throw new Error('Research user not found');
+    }
+    return researchUser;
+  }
+}

--- a/src/app/secure-data-environment/fake/fake.organisation.endpoints.spec.ts
+++ b/src/app/secure-data-environment/fake/fake.organisation.endpoints.spec.ts
@@ -1,0 +1,80 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { SdeEndpointsService } from '../sde-endpoints.service';
+import { cold } from 'jest-marbles';
+import { setupTestModuleForService } from 'src/app/testing/testing.helpers';
+import { TestBed } from '@angular/core/testing';
+import { FakeResources } from './fake-resources';
+
+describe('OrganisationEndPoints', () => {
+  let sdeEndpointsService: SdeEndpointsService;
+  let fakeResources: FakeResources;
+
+  beforeEach(() => {
+    sdeEndpointsService = setupTestModuleForService(SdeEndpointsService, {});
+    fakeResources = TestBed.inject(FakeResources);
+  });
+
+  it('should get an organisation', () => {
+    const expectedOrganisation = fakeResources.organisations[0];
+
+    const actualOrganisation = sdeEndpointsService.organisation.getOrganisation(
+      fakeResources.organisations[0].id
+    );
+
+    const expected = cold('(a|)', { a: expectedOrganisation });
+    expect(actualOrganisation).toBeObservable(expected);
+  });
+
+  it('should list organisations', () => {
+    const expectedOrganisation = fakeResources.organisations;
+
+    const actualOrganisation = sdeEndpointsService.organisation.listOrganisations();
+
+    const expected = cold('(a|)', { a: expectedOrganisation });
+    expect(actualOrganisation).toBeObservable(expected);
+  });
+
+  it('should get an organisation member', () => {
+    const expectedOrganisationMember = fakeResources.organisationMembers[0];
+
+    const actualOrganisationMember =
+      sdeEndpointsService.organisation.getOrganisationMember(
+        fakeResources.organisationMembers[0].id
+      );
+
+    const expected = cold('(a|)', { a: expectedOrganisationMember });
+    expect(actualOrganisationMember).toBeObservable(expected);
+  });
+
+  it('should list organisationMembers', () => {
+    const expectedOrganisationMembers = fakeResources.organisationMembers.filter(
+      (organisationMember) =>
+        organisationMember.organisationId === fakeResources.organisations[0].id
+    );
+
+    const actualOrganisationMembers =
+      sdeEndpointsService.organisation.listOrganisationMembers(
+        fakeResources.organisations[0].id
+      );
+
+    const expected = cold('(a|)', { a: expectedOrganisationMembers });
+    expect(actualOrganisationMembers).toBeObservable(expected);
+  });
+});

--- a/src/app/secure-data-environment/fake/fake.organisation.endpoints.spec.ts
+++ b/src/app/secure-data-environment/fake/fake.organisation.endpoints.spec.ts
@@ -51,18 +51,6 @@ describe('OrganisationEndPoints', () => {
     expect(actualOrganisation).toBeObservable(expected);
   });
 
-  it('should get an organisation member', () => {
-    const expectedOrganisationMember = fakeResources.organisationMembers[0];
-
-    const actualOrganisationMember =
-      sdeEndpointsService.organisation.getOrganisationMember(
-        fakeResources.organisationMembers[0].id
-      );
-
-    const expected = cold('(a|)', { a: expectedOrganisationMember });
-    expect(actualOrganisationMember).toBeObservable(expected);
-  });
-
   it('should list organisationMembers', () => {
     const expectedOrganisationMembers = fakeResources.organisationMembers.filter(
       (organisationMember) =>

--- a/src/app/secure-data-environment/fake/fake.user.endpoints.spec.ts
+++ b/src/app/secure-data-environment/fake/fake.user.endpoints.spec.ts
@@ -1,0 +1,55 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { SdeEndpointsService } from '../sde-endpoints.service';
+import { cold } from 'jest-marbles';
+import { setupTestModuleForService } from 'src/app/testing/testing.helpers';
+import { TestBed } from '@angular/core/testing';
+import { FakeResources } from './fake-resources';
+
+describe('UserEndPoints', () => {
+  let sdeEndpointsService: SdeEndpointsService;
+  let fakeResources: FakeResources;
+
+  beforeEach(() => {
+    sdeEndpointsService = setupTestModuleForService(SdeEndpointsService, {});
+    fakeResources = TestBed.inject(FakeResources);
+  });
+
+  it('should get an admin user', () => {
+    const expectedAdminUser = fakeResources.adminUsers[0];
+
+    const actualAdminUser = sdeEndpointsService.user.getAdminUser(
+      fakeResources.adminUsers[0].id
+    );
+
+    const expected = cold('(a|)', { a: expectedAdminUser });
+    expect(actualAdminUser).toBeObservable(expected);
+  });
+
+  it('should get a research user', () => {
+    const expectedAdminUser = fakeResources.adminUsers[0];
+
+    const actualAdminUser = sdeEndpointsService.user.getAdminUser(
+      fakeResources.adminUsers[0].id
+    );
+
+    const expected = cold('(a|)', { a: expectedAdminUser });
+    expect(actualAdminUser).toBeObservable(expected);
+  });
+});

--- a/src/app/secure-data-environment/resources/organisation.resources.ts
+++ b/src/app/secure-data-environment/resources/organisation.resources.ts
@@ -1,0 +1,39 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Uuid } from '@maurodatamapper/mdm-resources';
+
+export interface Organisation {
+  id: Uuid;
+  createdAt: Date;
+  createdBy: Uuid;
+  name: string;
+  description: string;
+  mauroCoreGroup: string;
+  isDeleted: boolean;
+}
+
+export interface OrganisationMember {
+  id: Uuid;
+  createdAt: Date;
+  createdBy: Uuid;
+  organisationId: Uuid;
+  userId: Uuid;
+  role: string;
+  endDate: Date;
+}

--- a/src/app/secure-data-environment/resources/users.resources.ts
+++ b/src/app/secure-data-environment/resources/users.resources.ts
@@ -1,0 +1,33 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Uuid } from '@maurodatamapper/mdm-resources';
+
+interface User {
+  id: Uuid;
+  createdAt: Date;
+  email: string;
+  mauroCoreUser: string;
+  isDeleted: boolean;
+  oidcIssuingAuthority: string;
+  oidcSubject: string;
+}
+
+export type AdminUser = User;
+
+export type ResearchUser = User;

--- a/src/app/secure-data-environment/sde-endpoints.service.ts
+++ b/src/app/secure-data-environment/sde-endpoints.service.ts
@@ -1,0 +1,36 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Injectable } from '@angular/core';
+import { FakeSdeRestHandler } from './fake/fake-sde-rest-handler';
+import { OrganisationEndpoints } from './endpoints/organisation.endpoints';
+import { SdeRestHandler } from './sde-rest-handler';
+import { UserEndpoints } from './endpoints/user.endpoints';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SdeEndpointsService {
+  organisation = new OrganisationEndpoints(this.fakeSdeRestHandler);
+  user = new UserEndpoints(this.fakeSdeRestHandler);
+
+  constructor(
+    private sdeRestHandler: SdeRestHandler,
+    private fakeSdeRestHandler: FakeSdeRestHandler
+  ) {}
+}

--- a/src/app/secure-data-environment/sde-rest-handler.interface.ts
+++ b/src/app/secure-data-environment/sde-rest-handler.interface.ts
@@ -1,0 +1,21 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+export interface ISdeRestHandler {
+  get<T>(url: string): any; // eslint-disable-line @typescript-eslint/no-unused-vars
+}

--- a/src/app/secure-data-environment/sde-rest-handler.ts
+++ b/src/app/secure-data-environment/sde-rest-handler.ts
@@ -1,0 +1,48 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { ISdeRestHandler } from './sde-rest-handler.interface';
+import { Injectable } from '@angular/core';
+import { catchError, throwError } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SdeRestHandler implements ISdeRestHandler {
+  constructor(private httpClient: HttpClient) {}
+
+  get<T>(url: string): any {
+    return this.httpClient
+      .get<T>(url)
+      .pipe(catchError((error) => this.handleError(error)));
+  }
+
+  private handleError(error: HttpErrorResponse) {
+    if (error.status === 0) {
+      // A client-side or network error occurred. Handle it accordingly.
+      console.error('An error occurred:', error.error);
+    } else {
+      // The backend returned an unsuccessful response code.
+      // The response body may contain clues as to what went wrong.
+      console.error(`Backend returned code ${error.status}, body was: `, error.error);
+    }
+    // Return an observable with a user-facing error message.
+    return throwError(() => new Error('Communication with the API failure'));
+  }
+}

--- a/src/app/shared/theme.service.ts
+++ b/src/app/shared/theme.service.ts
@@ -258,7 +258,7 @@ export class ThemeService {
 
   private getImageUrl(value: string): string | undefined {
     return value && isUuid(value)
-      ? `${environment.apiEndpoint}/themeImageFiles/${value}`
+      ? `${environment.mauroCoreEndpoint}/themeImageFiles/${value}`
       : undefined;
   }
 

--- a/src/app/testing/testing.helpers.ts
+++ b/src/app/testing/testing.helpers.ts
@@ -79,6 +79,7 @@ export const setupTestModuleForService = <T>(
   TestBed.configureTestingModule({
     imports: [TestingModule, ...(configuration?.imports ?? [])],
     providers: configuration?.providers ?? [],
+    teardown: { destroyAfterEach: false },
   });
   return TestBed.inject(service);
 };

--- a/src/app/testing/testing.helpers.ts
+++ b/src/app/testing/testing.helpers.ts
@@ -79,7 +79,6 @@ export const setupTestModuleForService = <T>(
   TestBed.configureTestingModule({
     imports: [TestingModule, ...(configuration?.imports ?? [])],
     providers: configuration?.providers ?? [],
-    teardown: { destroyAfterEach: false },
   });
   return TestBed.inject(service);
 };

--- a/src/environments/env.d.ts
+++ b/src/environments/env.d.ts
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 interface EnvironmentVariables {
-  apiEndpoint: string;
+  mauroCoreEndpoint: string;
 }
 
 declare let $ENV: EnvironmentVariables;

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 export const environment = {
   production: true,
-  apiEndpoint: $ENV.apiEndpoint ?? 'api',
+  mauroCoreEndpoint: $ENV.mauroCoreEndpoint ?? 'api',
   checkSessionExpiryTimeout: 300000,
   features: {
     useOpenIdConnect: true,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -23,6 +23,7 @@ SPDX-License-Identifier: Apache-2.0
 export const environment = {
   production: false,
   apiEndpoint: 'http://localhost:8080/api',
+  sdeApiEndpoint: 'to be defined',
   checkSessionExpiryTimeout: 300000,
   features: {
     useOpenIdConnect: true,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -22,8 +22,8 @@ SPDX-License-Identifier: Apache-2.0
 
 export const environment = {
   production: false,
-  apiEndpoint: 'http://localhost:8080/api',
-  sdeApiEndpoint: 'to be defined',
+  mauroCoreEndpoint: 'http://localhost:8080/api',
+  mauroSdeEndpoint: 'to be defined',
   checkSessionExpiryTimeout: 300000,
   features: {
     useOpenIdConnect: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,7 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin({
       $ENV: {
-        apiEndpoint: JSON.stringify(process.env["MDM_EXPLORER_API_ENDPOINT"]),
+        mauroCoreEndpoint: JSON.stringify(process.env["MDM_EXPLORER_API_ENDPOINT"]),
       },
     }),
   ],


### PR DESCRIPTION
This PR will be marked as "draft" until [PluginExplorer/32](https://github.com/MauroDataMapper-Plugins/mdm-plugin-explorer/pull/33) finishes.

This PR includes 2 new features:
- Share button when reviewing your data specification details. There is a new button, that opens a new dialog letting the user share that with the community (i.e. mark it as readableByAuthenticatedUsers)
- Shared with community data specs now are listed in the templates page. There is a new filter at the top, to show templates or shared with community data specs. 

When clicking a data specification title in the list in the templates page, the user can review the details of such spec. On the data spec details page, if the user viewing the details is not the author of such request all buttons to edit, submit, share etc will be hidden from him, also the "Back to my data specs" button will be a "back to templates" button.

I've tried to disable the buttons rather than hide them, but I recall a conversation about UI saying that buttons should be removed rather than disabled. I'm open to suggestions in that front. Should we include some sort of message to let the user now that all those actions are hidden because editing other user's requests is not allowed?

Closes #312 