### PR TITLE
gh-330: Create SDE Adaptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Set the api root in the enviroment
 create a distribution with the custom api set 
 `npm run dist`
 
-OPTIONAL - you can check `root/dist/yourSnapshotName/main.*` and note apiEndpoint to see if it took
+OPTIONAL - you can check `root/dist/yourSnapshotName/main.*` and note mauroCoreEndpoint to see if it took
 
 deploy your distribution to a httpserver
 install the httpserver `npm install --global http-server`

--- a/jest.config.js
+++ b/jest.config.js
@@ -35,7 +35,7 @@ module.exports = {
       stringifyContentPathRegex: "\\.html",
     },
     $ENV: {
-      apiEndpoint: "test-endpoint",
+      mauroCoreEndpoint: "test-endpoint",
     },
   },
   moduleNameMapper: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "rxjs": "7.4.0",
         "tinycolor2": "1.6.0",
         "tslib": "2.3.1",
+        "uuid": "^9.0.0",
         "zone.js": "0.11.5"
       },
       "devDependencies": {
@@ -3962,6 +3963,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@angular/cli/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@angular/common": {
@@ -15453,6 +15463,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/jest-junit/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/jest-leak-detector": {
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-28.1.3.tgz",
@@ -20981,6 +21000,15 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/socks": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
@@ -22126,10 +22154,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -25449,6 +25476,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
         }
       }
     },
@@ -34000,6 +34033,12 @@
           "requires": {
             "ansi-regex": "^4.1.0"
           }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
         }
       }
     },
@@ -38026,6 +38065,14 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "socks": {
@@ -38885,10 +38932,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "rxjs": "7.4.0",
     "tinycolor2": "1.6.0",
     "tslib": "2.3.1",
+    "uuid": "^9.0.0",
     "zone.js": "0.11.5"
   },
   "devDependencies": {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -288,11 +288,11 @@ export class AppComponent implements OnInit, OnDestroy {
 
   private setupSignedInUser(user?: UserDetails | null) {
     this.signedInUserProfileImageSrc = user
-      ? `${environment.apiEndpoint}/catalogueUsers/${user.id}/image`
+      ? `${environment.mauroCoreEndpoint}/catalogueUsers/${user.id}/image`
       : undefined;
     this.signedInUser = user;
     this.signedInUserProfileImageSrc = user
-      ? `${environment.apiEndpoint}/catalogueUsers/${user.id}/image`
+      ? `${environment.mauroCoreEndpoint}/catalogueUsers/${user.id}/image`
       : undefined;
   }
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -125,7 +125,7 @@ export const DATE_FORMATS: MatDateFormats = {
     CoreModule,
     SharedModule,
     MauroModule.forRoot({
-      apiEndpoint: environment.apiEndpoint,
+      apiEndpoint: environment.mauroCoreEndpoint,
       defaultHttpRequestOptions: {
         withCredentials: true,
       },

--- a/src/app/mauro/environment.service.spec.ts
+++ b/src/app/mauro/environment.service.spec.ts
@@ -47,6 +47,6 @@ describe('EnvironmentService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
-    expect(service.apiEndpoint).toBe($ENV.apiEndpoint);
+    expect(service.mauroCoreEndpoint).toBe($ENV.mauroCoreEndpoint);
   });
 });

--- a/src/app/mauro/environment.service.ts
+++ b/src/app/mauro/environment.service.ts
@@ -24,5 +24,5 @@ import { environment } from 'src/environments/environment.prod';
   providedIn: 'root',
 })
 export class EnvironmentService {
-  readonly apiEndpoint?: string = environment?.apiEndpoint;
+  readonly mauroCoreEndpoint?: string = environment?.mauroCoreEndpoint;
 }

--- a/src/app/secure-data-environment/endpoints/endpoints.dictionary.ts
+++ b/src/app/secure-data-environment/endpoints/endpoints.dictionary.ts
@@ -1,0 +1,26 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+export enum SdeApiEndPoints {
+  OrganisationList = '/organisation/list',
+  OrganisationGet = '/organisation/get?',
+  OrganisationMemberGet = '/organisation_member/get?',
+  OrganisationMemberList = '/organisation_member/list?',
+  AdminUserGet = '/user/admin/get?',
+  ResearchUserGet = '/user/research/get?',
+}

--- a/src/app/secure-data-environment/endpoints/organisation.endpoints.ts
+++ b/src/app/secure-data-environment/endpoints/organisation.endpoints.ts
@@ -35,12 +35,6 @@ export class OrganisationEndpoints {
     );
   }
 
-  getOrganisationMember(organisationMemberId: Uuid): Observable<OrganisationMember[]> {
-    return this.sdeRestHandler.get<OrganisationMember>(
-      `${SdeApiEndPoints.OrganisationMemberGet}${organisationMemberId}`
-    );
-  }
-
   listOrganisationMembers(organisationId: Uuid): Observable<OrganisationMember[]> {
     return this.sdeRestHandler.get<OrganisationMember[]>(
       `${SdeApiEndPoints.OrganisationMemberList}${organisationId}`

--- a/src/app/secure-data-environment/endpoints/organisation.endpoints.ts
+++ b/src/app/secure-data-environment/endpoints/organisation.endpoints.ts
@@ -1,0 +1,49 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Organisation, OrganisationMember } from '../resources/organisation.resources';
+import { Observable } from 'rxjs';
+import { ISdeRestHandler } from '../sde-rest-handler.interface';
+import { Uuid } from '@maurodatamapper/mdm-resources';
+import { SdeApiEndPoints } from './endpoints.dictionary';
+
+export class OrganisationEndpoints {
+  constructor(private sdeRestHandler: ISdeRestHandler) {}
+
+  listOrganisations(): Observable<Organisation[]> {
+    return this.sdeRestHandler.get<Organisation[]>(SdeApiEndPoints.OrganisationList);
+  }
+
+  getOrganisation(organisationId: Uuid): Observable<Organisation> {
+    return this.sdeRestHandler.get<Organisation>(
+      `${SdeApiEndPoints.OrganisationGet}${organisationId}`
+    );
+  }
+
+  getOrganisationMember(organisationMemberId: Uuid): Observable<OrganisationMember[]> {
+    return this.sdeRestHandler.get<OrganisationMember>(
+      `${SdeApiEndPoints.OrganisationMemberGet}${organisationMemberId}`
+    );
+  }
+
+  listOrganisationMembers(organisationId: Uuid): Observable<OrganisationMember[]> {
+    return this.sdeRestHandler.get<OrganisationMember[]>(
+      `${SdeApiEndPoints.OrganisationMemberList}${organisationId}`
+    );
+  }
+}

--- a/src/app/secure-data-environment/endpoints/user.endpoints.ts
+++ b/src/app/secure-data-environment/endpoints/user.endpoints.ts
@@ -1,0 +1,37 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Observable } from 'rxjs';
+import { ISdeRestHandler } from '../sde-rest-handler.interface';
+import { Uuid } from '@maurodatamapper/mdm-resources';
+import { SdeApiEndPoints } from './endpoints.dictionary';
+import { AdminUser, ResearchUser } from '../resources/users.resources';
+
+export class UserEndpoints {
+  constructor(private sdeRestHandler: ISdeRestHandler) {}
+
+  getAdminUser(userId: Uuid): Observable<AdminUser> {
+    return this.sdeRestHandler.get<AdminUser>(`${SdeApiEndPoints.AdminUserGet}${userId}`);
+  }
+
+  getResearchUser(userId: Uuid): Observable<ResearchUser> {
+    return this.sdeRestHandler.get<ResearchUser>(
+      `${SdeApiEndPoints.ResearchUserGet}${userId}`
+    );
+  }
+}

--- a/src/app/secure-data-environment/fake/fake-resources.ts
+++ b/src/app/secure-data-environment/fake/fake-resources.ts
@@ -1,0 +1,119 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Injectable } from '@angular/core';
+import { Organisation, OrganisationMember } from '../resources/organisation.resources';
+import { AdminUser, ResearchUser } from '../resources/users.resources';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FakeResources {
+  adminUsers: AdminUser[] = [
+    {
+      id: '15eaf2b0-833a-434a-ad3e-57de2f4b0885',
+      createdAt: new Date('2023-04-25T00:00:00.000Z'),
+      email: 'admin1@test.com',
+      mauroCoreUser: 'coreUser (admin1@test.com)',
+      isDeleted: false,
+      oidcIssuingAuthority: 'Issuing Authority (admin1@test.com)',
+      oidcSubject: 'Subject (admin1@test.com)',
+    },
+  ];
+
+  researchUsers: ResearchUser[] = [
+    {
+      id: '93f4e049-5105-42f8-aaa3-1925a0f52561',
+      createdAt: new Date('2023-04-25T00:00:00.000Z'),
+      email: 'researcher1@test.com',
+      mauroCoreUser: 'coreUser (researcher1@test.com)',
+      isDeleted: false,
+      oidcIssuingAuthority: 'Issuing Authority (researcher1@test.com)',
+      oidcSubject: 'Subject (researcher1@test.com)',
+    },
+    {
+      id: 'a84114f2-41ab-41e4-a88a-08ec0d3976fc',
+      createdAt: new Date('2023-04-25T00:00:00.000Z'),
+      email: 'researcher2@test.com',
+      mauroCoreUser: 'coreUser (researcher2@test.com)',
+      isDeleted: false,
+      oidcIssuingAuthority: 'Issuing Authority (researcher2@test.com)',
+      oidcSubject: 'Subject (researcher2@test.com)',
+    },
+    {
+      id: '76062aa2-a67e-4a76-88bb-e63c878606ee',
+      createdAt: new Date('2023-04-25T00:00:00.000Z'),
+      email: 'researcher3@test.com',
+      mauroCoreUser: 'coreUser (researcher3@test.com)',
+      isDeleted: false,
+      oidcIssuingAuthority: 'Issuing Authority (researcher3@test.com)',
+      oidcSubject: 'Subject (researcher3@test.com)',
+    },
+  ];
+
+  organisations: Organisation[] = [
+    {
+      id: 'e4e49288-3c0a-4b98-a387-2a813c1bd7fa',
+      createdBy: this.adminUsers[0].id,
+      createdAt: new Date('2023-04-28T00:00:00.000Z'),
+      name: 'Fake Org 1',
+      description: 'A fake organisation for development (Fake Org 1)',
+      mauroCoreGroup: 'Mauro core group (Fake Org 1)',
+      isDeleted: false,
+    },
+    {
+      id: '441d4474-f92c-4152-bd4a-17ce04b1a20d',
+      createdBy: this.adminUsers[0].id,
+      createdAt: new Date('2023-04-28T00:00:00.000Z'),
+      name: 'Fake Org 2',
+      description: 'A fake organisation for development (Fake Org 2)',
+      mauroCoreGroup: 'Mauro core group (Fake Org 2)',
+      isDeleted: false,
+    },
+    {
+      id: '6d6bd8c3-daa3-4a7c-b9c2-6d1f0893705b',
+      createdBy: this.adminUsers[0].id,
+      createdAt: new Date('2023-04-28T00:00:00.000Z'),
+      name: 'Fake Org 3',
+      description: 'A fake organisation for development (Fake Org 3)',
+      mauroCoreGroup: 'Mauro core group (Fake Org 3)',
+      isDeleted: false,
+    },
+  ];
+
+  organisationMembers: OrganisationMember[] = [
+    {
+      id: '5be65c1e-d937-46da-a46c-926d5664dcb6',
+      createdAt: new Date('2023-04-25T00:00:00.000Z'),
+      createdBy: this.adminUsers[0].id,
+      organisationId: this.organisations[0].id,
+      userId: this.researchUsers[0].id,
+      role: 'To be done',
+      endDate: new Date('2023-04-30T00:00:00.000Z'),
+    },
+    {
+      id: '99ea18c4-6057-4381-bb6c-405165190a90',
+      createdAt: new Date('2023-04-25T00:00:00.000Z'),
+      createdBy: this.adminUsers[0].id,
+      organisationId: this.organisations[0].id,
+      userId: this.researchUsers[1].id,
+      role: 'To be done',
+      endDate: new Date('2023-04-30T00:00:00.000Z'),
+    },
+  ];
+}

--- a/src/app/secure-data-environment/fake/fake-sde-rest-handler.ts
+++ b/src/app/secure-data-environment/fake/fake-sde-rest-handler.ts
@@ -36,8 +36,6 @@ export class FakeSdeRestHandler implements ISdeRestHandler {
       return of(this.getOrganisationList());
     } else if (url.startsWith(SdeApiEndPoints.OrganisationGet)) {
       return of(this.getOrganisation(url));
-    } else if (url.startsWith(SdeApiEndPoints.OrganisationMemberGet)) {
-      return of(this.getOrganisationMember(url));
     } else if (url.startsWith(SdeApiEndPoints.OrganisationMemberList)) {
       return of(this.getOrganisationMemberList(url));
     } else if (url.startsWith(SdeApiEndPoints.AdminUserGet)) {

--- a/src/app/secure-data-environment/fake/fake-sde-rest-handler.ts
+++ b/src/app/secure-data-environment/fake/fake-sde-rest-handler.ts
@@ -1,0 +1,110 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Injectable } from '@angular/core';
+import { ISdeRestHandler } from '../sde-rest-handler.interface';
+import { Organisation, OrganisationMember } from '../resources/organisation.resources';
+import { SdeApiEndPoints } from '../endpoints/endpoints.dictionary';
+import { of } from 'rxjs';
+import { AdminUser, ResearchUser } from '../resources/users.resources';
+import { Uuid } from '@maurodatamapper/mdm-resources';
+import { FakeResources } from './fake-resources';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FakeSdeRestHandler implements ISdeRestHandler {
+  constructor(private fakeResources: FakeResources) {}
+
+  get(url: string): any {
+    if (url === SdeApiEndPoints.OrganisationList) {
+      return of(this.getOrganisationList());
+    } else if (url.startsWith(SdeApiEndPoints.OrganisationGet)) {
+      return of(this.getOrganisation(url));
+    } else if (url.startsWith(SdeApiEndPoints.OrganisationMemberGet)) {
+      return of(this.getOrganisationMember(url));
+    } else if (url.startsWith(SdeApiEndPoints.OrganisationMemberList)) {
+      return of(this.getOrganisationMemberList(url));
+    } else if (url.startsWith(SdeApiEndPoints.AdminUserGet)) {
+      return of(this.getAdminUser(url));
+    } else if (url.startsWith(SdeApiEndPoints.ResearchUserGet)) {
+      return of(this.getResearchUser(url));
+    }
+  }
+
+  private getIdFromUrl(url: string) {
+    const splitUrl = url.split('?');
+    if (splitUrl.length === 2) {
+      return splitUrl[1];
+    }
+    throw new Error('Unable to find id in url string');
+  }
+
+  private getOrganisation(url: string): Organisation {
+    const id: Uuid = this.getIdFromUrl(url);
+    const organisation = this.fakeResources.organisations.find((org) => org.id === id);
+    if (organisation == null) {
+      throw new Error('Organisation not found');
+    }
+    return organisation;
+  }
+
+  private getOrganisationList(): Organisation[] {
+    return this.fakeResources.organisations;
+  }
+
+  private getOrganisationMember(url: string): OrganisationMember {
+    const id: Uuid = this.getIdFromUrl(url);
+    const organisationMember = this.fakeResources.organisationMembers.find(
+      (orgMember) => orgMember.id === id
+    );
+    if (organisationMember == null) {
+      throw new Error('Organisation Member not found');
+    }
+    return organisationMember;
+  }
+
+  private getOrganisationMemberList(url: string): OrganisationMember[] {
+    const id: Uuid = this.getIdFromUrl(url);
+    const organisationMembers = this.fakeResources.organisationMembers.filter(
+      (orgMember) => orgMember.organisationId === id
+    );
+    if (organisationMembers == null) {
+      throw new Error('Organisation Members not found');
+    }
+    return organisationMembers;
+  }
+
+  private getAdminUser(url: string): AdminUser {
+    const id: Uuid = this.getIdFromUrl(url);
+    const adminUser = this.fakeResources.adminUsers.find((user) => user.id === id);
+    if (adminUser == null) {
+      throw new Error('Admin user not found');
+    }
+    return adminUser;
+  }
+
+  private getResearchUser(url: string): ResearchUser {
+    const id: Uuid = this.getIdFromUrl(url);
+    const researchUser = this.fakeResources.researchUsers.find((user) => user.id === id);
+    if (researchUser == null) {
+      throw new Error('Research user not found');
+    }
+    return researchUser;
+  }
+}

--- a/src/app/secure-data-environment/fake/fake.organisation.endpoints.spec.ts
+++ b/src/app/secure-data-environment/fake/fake.organisation.endpoints.spec.ts
@@ -1,0 +1,80 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { SdeEndpointsService } from '../sde-endpoints.service';
+import { cold } from 'jest-marbles';
+import { setupTestModuleForService } from 'src/app/testing/testing.helpers';
+import { TestBed } from '@angular/core/testing';
+import { FakeResources } from './fake-resources';
+
+describe('OrganisationEndPoints', () => {
+  let sdeEndpointsService: SdeEndpointsService;
+  let fakeResources: FakeResources;
+
+  beforeEach(() => {
+    sdeEndpointsService = setupTestModuleForService(SdeEndpointsService, {});
+    fakeResources = TestBed.inject(FakeResources);
+  });
+
+  it('should get an organisation', () => {
+    const expectedOrganisation = fakeResources.organisations[0];
+
+    const actualOrganisation = sdeEndpointsService.organisation.getOrganisation(
+      fakeResources.organisations[0].id
+    );
+
+    const expected = cold('(a|)', { a: expectedOrganisation });
+    expect(actualOrganisation).toBeObservable(expected);
+  });
+
+  it('should list organisations', () => {
+    const expectedOrganisation = fakeResources.organisations;
+
+    const actualOrganisation = sdeEndpointsService.organisation.listOrganisations();
+
+    const expected = cold('(a|)', { a: expectedOrganisation });
+    expect(actualOrganisation).toBeObservable(expected);
+  });
+
+  it('should get an organisation member', () => {
+    const expectedOrganisationMember = fakeResources.organisationMembers[0];
+
+    const actualOrganisationMember =
+      sdeEndpointsService.organisation.getOrganisationMember(
+        fakeResources.organisationMembers[0].id
+      );
+
+    const expected = cold('(a|)', { a: expectedOrganisationMember });
+    expect(actualOrganisationMember).toBeObservable(expected);
+  });
+
+  it('should list organisationMembers', () => {
+    const expectedOrganisationMembers = fakeResources.organisationMembers.filter(
+      (organisationMember) =>
+        organisationMember.organisationId === fakeResources.organisations[0].id
+    );
+
+    const actualOrganisationMembers =
+      sdeEndpointsService.organisation.listOrganisationMembers(
+        fakeResources.organisations[0].id
+      );
+
+    const expected = cold('(a|)', { a: expectedOrganisationMembers });
+    expect(actualOrganisationMembers).toBeObservable(expected);
+  });
+});

--- a/src/app/secure-data-environment/fake/fake.organisation.endpoints.spec.ts
+++ b/src/app/secure-data-environment/fake/fake.organisation.endpoints.spec.ts
@@ -51,18 +51,6 @@ describe('OrganisationEndPoints', () => {
     expect(actualOrganisation).toBeObservable(expected);
   });
 
-  it('should get an organisation member', () => {
-    const expectedOrganisationMember = fakeResources.organisationMembers[0];
-
-    const actualOrganisationMember =
-      sdeEndpointsService.organisation.getOrganisationMember(
-        fakeResources.organisationMembers[0].id
-      );
-
-    const expected = cold('(a|)', { a: expectedOrganisationMember });
-    expect(actualOrganisationMember).toBeObservable(expected);
-  });
-
   it('should list organisationMembers', () => {
     const expectedOrganisationMembers = fakeResources.organisationMembers.filter(
       (organisationMember) =>

--- a/src/app/secure-data-environment/fake/fake.user.endpoints.spec.ts
+++ b/src/app/secure-data-environment/fake/fake.user.endpoints.spec.ts
@@ -1,0 +1,55 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { SdeEndpointsService } from '../sde-endpoints.service';
+import { cold } from 'jest-marbles';
+import { setupTestModuleForService } from 'src/app/testing/testing.helpers';
+import { TestBed } from '@angular/core/testing';
+import { FakeResources } from './fake-resources';
+
+describe('UserEndPoints', () => {
+  let sdeEndpointsService: SdeEndpointsService;
+  let fakeResources: FakeResources;
+
+  beforeEach(() => {
+    sdeEndpointsService = setupTestModuleForService(SdeEndpointsService, {});
+    fakeResources = TestBed.inject(FakeResources);
+  });
+
+  it('should get an admin user', () => {
+    const expectedAdminUser = fakeResources.adminUsers[0];
+
+    const actualAdminUser = sdeEndpointsService.user.getAdminUser(
+      fakeResources.adminUsers[0].id
+    );
+
+    const expected = cold('(a|)', { a: expectedAdminUser });
+    expect(actualAdminUser).toBeObservable(expected);
+  });
+
+  it('should get a research user', () => {
+    const expectedAdminUser = fakeResources.adminUsers[0];
+
+    const actualAdminUser = sdeEndpointsService.user.getAdminUser(
+      fakeResources.adminUsers[0].id
+    );
+
+    const expected = cold('(a|)', { a: expectedAdminUser });
+    expect(actualAdminUser).toBeObservable(expected);
+  });
+});

--- a/src/app/secure-data-environment/resources/organisation.resources.ts
+++ b/src/app/secure-data-environment/resources/organisation.resources.ts
@@ -1,0 +1,39 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Uuid } from '@maurodatamapper/mdm-resources';
+
+export interface Organisation {
+  id: Uuid;
+  createdAt: Date;
+  createdBy: Uuid;
+  name: string;
+  description: string;
+  mauroCoreGroup: string;
+  isDeleted: boolean;
+}
+
+export interface OrganisationMember {
+  id: Uuid;
+  createdAt: Date;
+  createdBy: Uuid;
+  organisationId: Uuid;
+  userId: Uuid;
+  role: string;
+  endDate: Date;
+}

--- a/src/app/secure-data-environment/resources/users.resources.ts
+++ b/src/app/secure-data-environment/resources/users.resources.ts
@@ -1,0 +1,33 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Uuid } from '@maurodatamapper/mdm-resources';
+
+interface User {
+  id: Uuid;
+  createdAt: Date;
+  email: string;
+  mauroCoreUser: string;
+  isDeleted: boolean;
+  oidcIssuingAuthority: string;
+  oidcSubject: string;
+}
+
+export type AdminUser = User;
+
+export type ResearchUser = User;

--- a/src/app/secure-data-environment/sde-endpoints.service.ts
+++ b/src/app/secure-data-environment/sde-endpoints.service.ts
@@ -1,0 +1,36 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Injectable } from '@angular/core';
+import { FakeSdeRestHandler } from './fake/fake-sde-rest-handler';
+import { OrganisationEndpoints } from './endpoints/organisation.endpoints';
+import { SdeRestHandler } from './sde-rest-handler';
+import { UserEndpoints } from './endpoints/user.endpoints';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SdeEndpointsService {
+  organisation = new OrganisationEndpoints(this.fakeSdeRestHandler);
+  user = new UserEndpoints(this.fakeSdeRestHandler);
+
+  constructor(
+    private sdeRestHandler: SdeRestHandler,
+    private fakeSdeRestHandler: FakeSdeRestHandler
+  ) {}
+}

--- a/src/app/secure-data-environment/sde-rest-handler.interface.ts
+++ b/src/app/secure-data-environment/sde-rest-handler.interface.ts
@@ -1,0 +1,21 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+export interface ISdeRestHandler {
+  get<T>(url: string): any; // eslint-disable-line @typescript-eslint/no-unused-vars
+}

--- a/src/app/secure-data-environment/sde-rest-handler.ts
+++ b/src/app/secure-data-environment/sde-rest-handler.ts
@@ -1,0 +1,48 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { ISdeRestHandler } from './sde-rest-handler.interface';
+import { Injectable } from '@angular/core';
+import { catchError, throwError } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SdeRestHandler implements ISdeRestHandler {
+  constructor(private httpClient: HttpClient) {}
+
+  get<T>(url: string): any {
+    return this.httpClient
+      .get<T>(url)
+      .pipe(catchError((error) => this.handleError(error)));
+  }
+
+  private handleError(error: HttpErrorResponse) {
+    if (error.status === 0) {
+      // A client-side or network error occurred. Handle it accordingly.
+      console.error('An error occurred:', error.error);
+    } else {
+      // The backend returned an unsuccessful response code.
+      // The response body may contain clues as to what went wrong.
+      console.error(`Backend returned code ${error.status}, body was: `, error.error);
+    }
+    // Return an observable with a user-facing error message.
+    return throwError(() => new Error('Communication with the API failure'));
+  }
+}

--- a/src/app/shared/theme.service.ts
+++ b/src/app/shared/theme.service.ts
@@ -258,7 +258,7 @@ export class ThemeService {
 
   private getImageUrl(value: string): string | undefined {
     return value && isUuid(value)
-      ? `${environment.apiEndpoint}/themeImageFiles/${value}`
+      ? `${environment.mauroCoreEndpoint}/themeImageFiles/${value}`
       : undefined;
   }
 

--- a/src/app/testing/testing.helpers.ts
+++ b/src/app/testing/testing.helpers.ts
@@ -79,6 +79,7 @@ export const setupTestModuleForService = <T>(
   TestBed.configureTestingModule({
     imports: [TestingModule, ...(configuration?.imports ?? [])],
     providers: configuration?.providers ?? [],
+    teardown: { destroyAfterEach: false },
   });
   return TestBed.inject(service);
 };

--- a/src/app/testing/testing.helpers.ts
+++ b/src/app/testing/testing.helpers.ts
@@ -79,7 +79,6 @@ export const setupTestModuleForService = <T>(
   TestBed.configureTestingModule({
     imports: [TestingModule, ...(configuration?.imports ?? [])],
     providers: configuration?.providers ?? [],
-    teardown: { destroyAfterEach: false },
   });
   return TestBed.inject(service);
 };

--- a/src/environments/env.d.ts
+++ b/src/environments/env.d.ts
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 interface EnvironmentVariables {
-  apiEndpoint: string;
+  mauroCoreEndpoint: string;
 }
 
 declare let $ENV: EnvironmentVariables;

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 export const environment = {
   production: true,
-  apiEndpoint: $ENV.apiEndpoint ?? 'api',
+  mauroCoreEndpoint: $ENV.mauroCoreEndpoint ?? 'api',
   checkSessionExpiryTimeout: 300000,
   features: {
     useOpenIdConnect: true,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -23,6 +23,7 @@ SPDX-License-Identifier: Apache-2.0
 export const environment = {
   production: false,
   apiEndpoint: 'http://localhost:8080/api',
+  sdeApiEndpoint: 'to be defined',
   checkSessionExpiryTimeout: 300000,
   features: {
     useOpenIdConnect: true,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -22,8 +22,8 @@ SPDX-License-Identifier: Apache-2.0
 
 export const environment = {
   production: false,
-  apiEndpoint: 'http://localhost:8080/api',
-  sdeApiEndpoint: 'to be defined',
+  mauroCoreEndpoint: 'http://localhost:8080/api',
+  mauroSdeEndpoint: 'to be defined',
   checkSessionExpiryTimeout: 300000,
   features: {
     useOpenIdConnect: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,7 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin({
       $ENV: {
-        apiEndpoint: JSON.stringify(process.env["MDM_EXPLORER_API_ENDPOINT"]),
+        mauroCoreEndpoint: JSON.stringify(process.env["MDM_EXPLORER_API_ENDPOINT"]),
       },
     }),
   ],


### PR DESCRIPTION
This is an adaptor layer to fulfill #330 . The code has been organised so that all the fake code is in a folder together so that it can easily be removed down the line. Both real and fake rest handlers can live side by side, so that it will be possible to change where data is coming from iteratively, without having to do an all or nothing approach.

The tests written are to prove the fakes work, rather than to test the adaptor itself. Full tests will be required if this approach is accepted. 

The code written here will need to be copied to the SDE Admin UI. It became apparent whilst writing this, that a shared project would be required since a lot of this functionality will be shared between the two applications.