### PR TITLE
gh-343: Fix SDE environment settings for prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,11 +155,13 @@ The enviroment service will take a set enviroment key and expose a class with an
 
 Current enviroment keys:
 `MDM_EXPLORER_API_ENDPOINT` - the api web root
+`SDE_RESEARCHER_API_ENDPOINT` - the Secure Data Environment (SDE) api web root
 
 Example setup for a unix terminal:
 
 Set the api root in the enviroment
 `expose MDM_EXPLORER_API_ENDPOINT="MyTestEndpoint`
+`expose SDE_RESEARCHER_API_ENDPOINT="MySDETestEndpoint`
 
 create a distribution with the custom api set 
 `npm run dist`

--- a/src/app/mauro/environment.service.ts
+++ b/src/app/mauro/environment.service.ts
@@ -25,4 +25,5 @@ import { environment } from 'src/environments/environment.prod';
 })
 export class EnvironmentService {
   readonly mauroCoreEndpoint?: string = environment?.mauroCoreEndpoint;
+  readonly sdeResearcherEndpoint?: string = environment?.sdeResearcherEndpoint;
 }

--- a/src/environments/env.d.ts
+++ b/src/environments/env.d.ts
@@ -18,6 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 interface EnvironmentVariables {
   mauroCoreEndpoint: string;
+  sdeResearcherEndpoint: string;
 }
 
 declare let $ENV: EnvironmentVariables;

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -19,6 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 export const environment = {
   production: true,
   mauroCoreEndpoint: $ENV.mauroCoreEndpoint ?? 'api',
+  sdeResearcherEndpoint: $ENV.sdeResearcherEndpoint,
   checkSessionExpiryTimeout: 300000,
   features: {
     useOpenIdConnect: true,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -23,7 +23,6 @@ SPDX-License-Identifier: Apache-2.0
 export const environment = {
   production: false,
   mauroCoreEndpoint: 'http://localhost:8080/api',
-  sdeAdminEndpoint: 'http://localhost:8081',
   sdeResearcherEndpoint: 'http://localhost:8082',
   checkSessionExpiryTimeout: 300000,
   features: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,6 +44,7 @@ module.exports = {
     new webpack.DefinePlugin({
       $ENV: {
         mauroCoreEndpoint: JSON.stringify(process.env["MDM_EXPLORER_API_ENDPOINT"]),
+        sdeResearcherEndpoint: JSON.stringify(process.env["SDE_RESEARCHER_API_ENDPOINT"]),
       },
     }),
   ],


### PR DESCRIPTION
The sdeResearcherEndpoint environment variable has been added to the production build. Also note that sdeAdminEndpoint has been removed since this should not be present in mdm-explorer.