### PR TITLE
gh-354-use-workflow-resolver

### DIFF
--- a/src/app/pages/pages.routes.ts
+++ b/src/app/pages/pages.routes.ts
@@ -42,6 +42,7 @@ import { MyDataSpecificationDetailComponent } from './my-data-specification-deta
 import { TemplateDataSpecificationsComponent } from './template-data-specifications/template-data-specifications.component';
 import { TemplateDataSpecificationDetailComponent } from './template-data-specification-detail/template-data-specification-detail.component';
 import { SdeMainComponent } from './sde-main/sde-main.component';
+import { WorkflowResolver } from '@maurodatamapper/sde-resources';
 
 export const buildStaticContentRoute = (path: string, staticAssetPath: string): Route => {
   return {
@@ -187,5 +188,8 @@ export const routes: Route[] = [
     path: 'sde',
     component: SdeMainComponent,
     canActivate: [AuthorizedGuard],
+    resolve: {
+      workflow: WorkflowResolver,
+    },
   },
 ];


### PR DESCRIPTION
Add resolver to the SDE route. 

To test: verify that the workflow is loaded only upon navigating to the SDE route. 

closes #354 