### PR TITLE
gh-347 Update to display correct requests list for researchers

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -77,7 +77,11 @@
               "optimization": false,
               "vendorChunk": true,
               "extractLicenses": false,
-              "sourceMap": true,
+              "sourceMap": {
+                "scripts": true,
+                "styles": true,
+                "vendor": true
+              },
               "namedChunks": true
             }
           },

--- a/src/app/secure-data-environment/components/sde-requests/sde-requests.component.html
+++ b/src/app/secure-data-environment/components/sde-requests/sde-requests.component.html
@@ -16,6 +16,4 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<p>sde-requests works!</p>
-
-<sde-requests-list></sde-requests-list>
+<sde-requests-list [useConfig]="requestsListConfig"></sde-requests-list>

--- a/src/app/secure-data-environment/components/sde-requests/sde-requests.component.ts
+++ b/src/app/secure-data-environment/components/sde-requests/sde-requests.component.ts
@@ -17,17 +17,17 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Component, OnInit } from '@angular/core';
+import { RequestsListMode } from '@maurodatamapper/sde-resources';
 
 @Component({
   selector: 'mdm-sde-requests',
   templateUrl: './sde-requests.component.html',
-  styleUrls: ['./sde-requests.component.scss']
+  styleUrls: ['./sde-requests.component.scss'],
 })
 export class SdeRequestsComponent implements OnInit {
+  requestsListConfig: RequestsListMode = RequestsListMode.CreatedByMe;
 
-  constructor() { }
+  constructor() {}
 
-  ngOnInit(): void {
-  }
-
+  ngOnInit(): void {}
 }

--- a/src/app/shared/theme.service.ts
+++ b/src/app/shared/theme.service.ts
@@ -228,7 +228,6 @@ export class ThemeService {
 
   getColor(key: string): string {
     const typedKey = key as keyof typeof this.allCss;
-    console.log(`allCss.length = ${Object.keys(this.allCss)}`);
     return this.allCss[typedKey];
   }
 


### PR DESCRIPTION
Resolves #347 

- Supports the epic #351 
- Depends on MauroDataMapper/sde-core#128
- Depends on MauroDataMapper/sde-resources#34

Small updates to have `mdm-explorer` show the correct request list for researchers - most of the functionality for handling creation of requests is handled in the shared library.

# Notes

- Set correct display mode for `sde-requests-list` component

# Additional

- Update `angular.json` to support debugging of the `sde-resources` library/node package

# Testing

This PR, along with its dependencies, should support:

1. A researcher being able to create requests - into "Draft" status
2. Then being able to submit that request to "Awaiting Approval" status
3. A researcher having correct access to the request action links relevant to them

# Out of scope

- The issue #347 also states to have the request list component display the correct requests given the context i.e. I'm a researcher, I will see my requests I created etc. The UI is prepared for this, but the backend does not return the correct data. This has been pushed to MauroDataMapper/sde-core#132 to fix