### PR TITLE
gh-412 - Add user friendly dialog if submission of data specification fails. 

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -33,7 +33,11 @@ SPDX-License-Identifier: Apache-2.0
       <router-outlet></router-outlet>
     </main>
 
-    <mdm-loading-spinner *ngIf="isLoading" [caption]="loadingCaption"></mdm-loading-spinner>
+    <mdm-loading-spinner
+      *ngIf="isLoading"
+      [caption]="loadingCaption"
+      [fillviewport]="fillviewport"
+    ></mdm-loading-spinner>
   </div>
 
   <mdm-footer version="0.1.0" [links]="footerLinks"></mdm-footer>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -56,6 +56,7 @@ export class AppComponent implements OnInit, OnDestroy {
 
   isLoading = false;
   loadingCaption = '';
+  fillviewport = true;
 
   draftDataSpecificationsCount = 0;
 
@@ -259,6 +260,7 @@ export class AppComponent implements OnInit, OnDestroy {
       .subscribe((payload) => {
         this.isLoading = payload.isLoading;
         this.loadingCaption = payload.caption ?? '';
+        this.fillviewport = payload.fillviewport ?? true;
       });
 
     // Check immediately if the last authenticated session is expired and setup a recurring

--- a/src/app/core/broadcast.service.ts
+++ b/src/app/core/broadcast.service.ts
@@ -41,7 +41,10 @@ export type BroadcastEvent =
  * Represents a message to broadcast with an optional data payload.
  */
 export class BroadcastMessage<TPayload = any> {
-  constructor(public event: BroadcastEvent, public payload?: TPayload) {}
+  constructor(
+    public event: BroadcastEvent,
+    public payload?: TPayload
+  ) {}
 }
 
 /**
@@ -114,6 +117,7 @@ export class BroadcastService {
     this.loading({
       isLoading: true,
       caption: `Submitting your data specification - ${message}`,
+      fillviewport: false,
     });
   }
 }

--- a/src/app/core/core.types.ts
+++ b/src/app/core/core.types.ts
@@ -23,4 +23,5 @@ export const defaultEmailPattern =
 export interface LoadingBroadcastPayload {
   isLoading: boolean;
   caption?: string;
+  fillviewport?: boolean;
 }

--- a/src/app/data-explorer/data-explorer.module.ts
+++ b/src/app/data-explorer/data-explorer.module.ts
@@ -66,6 +66,7 @@ import { HasFieldsPipe } from './query-builder/pipes/has-fields-pipe';
 import { ArrowFormatPipe } from './query-builder/pipes/arrow-format-pipe';
 import { SelectProjectDialogComponent } from './specification-submission/select-project-dialog/select-project-dialog.component';
 import { ReadOnlyMeqlPipe } from './pipes/readonly-meql.pipe';
+import { SimpleDialogComponent } from './simple-dialog/simple-dialog.component';
 
 const queryBuilderModules = [
   QueryBuilderComponent,
@@ -99,6 +100,7 @@ const queryBuilderModules = [
     DataSpecificationCreatedDialogComponent,
     DataSpecificationUpdatedDialogComponent,
     SuccessDialogComponent,
+    SimpleDialogComponent,
     IdentifiableDataIconComponent,
     SearchFiltersComponent,
     CatalogueSearchFormComponent,

--- a/src/app/data-explorer/dialog.service.ts
+++ b/src/app/data-explorer/dialog.service.ts
@@ -52,10 +52,7 @@ import {
   DataSpecificationUpdatedData,
   DataSpecificationUpdatedDialogComponent,
 } from './data-specification-updated-dialog/data-specification-updated-dialog.component';
-import {
-  SuccessDialogComponent,
-  SuccessDialogData,
-} from './success-dialog/success-dialog.component';
+import { SuccessDialogComponent } from './success-dialog/success-dialog.component';
 import {
   ShareDataSpecificationDialogComponent,
   ShareDataSpecificationDialogInputOutput,
@@ -64,6 +61,7 @@ import {
   SelectProjectDialogComponent,
   SelectProjectDialogData,
 } from './specification-submission/select-project-dialog/select-project-dialog.component';
+import { SimpleDialogComponent, SimpleDialogData } from './simple-dialog/simple-dialog.component';
 
 @Injectable({
   providedIn: 'root',
@@ -111,13 +109,12 @@ export class DialogService {
   }
 
   openConfirmation(data: ConfirmationDialogConfig) {
-    return this.matDialog.open<
+    return this.matDialog.open<ConfirmationDialogComponent, ConfirmationDialogConfig, DialogResult>(
       ConfirmationDialogComponent,
-      ConfirmationDialogConfig,
-      DialogResult
-    >(ConfirmationDialogComponent, {
-      data,
-    });
+      {
+        data,
+      }
+    );
   }
 
   openFeedbackForm() {
@@ -127,24 +124,27 @@ export class DialogService {
   }
 
   openOkCancel(data: OkCancelDialogData) {
-    return this.matDialog.open<
+    return this.matDialog.open<OkCancelDialogComponent, OkCancelDialogData, OkCancelDialogResponse>(
       OkCancelDialogComponent,
-      OkCancelDialogData,
-      OkCancelDialogResponse
-    >(OkCancelDialogComponent, {
-      maxWidth: 500,
-      data,
-    });
-  }
-
-  openSuccess(data: SuccessDialogData) {
-    return this.matDialog.open<SuccessDialogComponent, SuccessDialogData>(
-      SuccessDialogComponent,
       {
         maxWidth: 500,
         data,
       }
     );
+  }
+
+  openSuccess(data: SimpleDialogData) {
+    return this.matDialog.open<SuccessDialogComponent, SimpleDialogData>(SuccessDialogComponent, {
+      maxWidth: 500,
+      data,
+    });
+  }
+
+  openSimple(data: SimpleDialogData) {
+    return this.matDialog.open<SimpleDialogComponent, SimpleDialogData>(SimpleDialogComponent, {
+      maxWidth: 500,
+      data,
+    });
   }
 
   shareWithCommunity(data: ShareDataSpecificationDialogInputOutput) {

--- a/src/app/data-explorer/simple-dialog/simple-dialog.component.html
+++ b/src/app/data-explorer/simple-dialog/simple-dialog.component.html
@@ -1,4 +1,4 @@
-/*
+<!--
 Copyright 2022-2023 University of Oxford
 and Health and Social Care Information Centre, also known as NHS Digital
 
@@ -15,21 +15,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
-*/
-import { Component, Inject } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { SimpleDialogComponent, SimpleDialogData } from '../simple-dialog/simple-dialog.component';
-
-@Component({
-  selector: 'mdm-success-dialog',
-  templateUrl: './success-dialog.component.html',
-  styleUrls: ['./success-dialog.component.scss'],
-})
-export class SuccessDialogComponent extends SimpleDialogComponent {
-  constructor(
-    dialogRef: MatDialogRef<SuccessDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) data: SimpleDialogData
-  ) {
-    super(dialogRef, data);
-  }
-}
+-->
+<h1 mat-dialog-title>{{ heading }}</h1>
+<mat-dialog-content *ngIf="message" [innerHTML]="message"> </mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-flat-button color="primary" (click)="close()">Continue</button>
+</mat-dialog-actions>

--- a/src/app/data-explorer/simple-dialog/simple-dialog.component.scss
+++ b/src/app/data-explorer/simple-dialog/simple-dialog.component.scss
@@ -16,20 +16,3 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { Component, Inject } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { SimpleDialogComponent, SimpleDialogData } from '../simple-dialog/simple-dialog.component';
-
-@Component({
-  selector: 'mdm-success-dialog',
-  templateUrl: './success-dialog.component.html',
-  styleUrls: ['./success-dialog.component.scss'],
-})
-export class SuccessDialogComponent extends SimpleDialogComponent {
-  constructor(
-    dialogRef: MatDialogRef<SuccessDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) data: SimpleDialogData
-  ) {
-    super(dialogRef, data);
-  }
-}

--- a/src/app/data-explorer/simple-dialog/simple-dialog.component.spec.ts
+++ b/src/app/data-explorer/simple-dialog/simple-dialog.component.spec.ts
@@ -25,11 +25,10 @@ import {
 import { MockDirective } from 'ng-mocks';
 import { createMatDialogRefStub } from 'src/app/testing/stubs/mat-dialog.stub';
 import { ComponentHarness, setupTestModuleForComponent } from 'src/app/testing/testing.helpers';
-import { SuccessDialogComponent } from './success-dialog.component';
-import { SimpleDialogData } from '../simple-dialog/simple-dialog.component';
+import { SimpleDialogComponent, SimpleDialogData } from './simple-dialog.component';
 
-describe('SuccessDialogComponent', () => {
-  let harness: ComponentHarness<SuccessDialogComponent>;
+describe('SimpleDialogComponent', () => {
+  let harness: ComponentHarness<SimpleDialogComponent>;
   const dialogRefStub = createMatDialogRefStub<void>();
 
   const data: SimpleDialogData = {
@@ -38,7 +37,7 @@ describe('SuccessDialogComponent', () => {
   };
 
   beforeEach(async () => {
-    harness = await setupTestModuleForComponent(SuccessDialogComponent, {
+    harness = await setupTestModuleForComponent(SimpleDialogComponent, {
       declarations: [MockDirective(MatDialogContent), MockDirective(MatDialogActions)],
       providers: [
         {

--- a/src/app/data-explorer/simple-dialog/simple-dialog.component.ts
+++ b/src/app/data-explorer/simple-dialog/simple-dialog.component.ts
@@ -18,18 +18,32 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { Component, Inject } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { SimpleDialogComponent, SimpleDialogData } from '../simple-dialog/simple-dialog.component';
+
+export interface SimpleDialogData {
+  heading: string;
+  message?: string;
+}
 
 @Component({
-  selector: 'mdm-success-dialog',
-  templateUrl: './success-dialog.component.html',
-  styleUrls: ['./success-dialog.component.scss'],
+  selector: 'mdm-simple-dialog',
+  templateUrl: './simple-dialog.component.html',
+  styleUrls: ['./simple-dialog.component.scss'],
 })
-export class SuccessDialogComponent extends SimpleDialogComponent {
+export class SimpleDialogComponent {
   constructor(
-    dialogRef: MatDialogRef<SuccessDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) data: SimpleDialogData
-  ) {
-    super(dialogRef, data);
+    private dialogRef: MatDialogRef<SimpleDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) private data: SimpleDialogData
+  ) {}
+
+  get heading() {
+    return this.data.heading;
+  }
+
+  get message() {
+    return this.data.message;
+  }
+
+  close() {
+    this.dialogRef.close();
   }
 }

--- a/src/app/data-explorer/specification-submission/services/specification-submission.service.ts
+++ b/src/app/data-explorer/specification-submission/services/specification-submission.service.ts
@@ -71,6 +71,7 @@ export class SpecificationSubmissionService {
    */
   submit(specificationId: Uuid): Observable<boolean> {
     // Set initial state.
+    this.stateService.clear();
     this.stateService.set({ specificationId });
 
     // Run each step, once at a time, ensuring it completes before running the next.

--- a/src/app/data-explorer/specification-submission/services/specification-submission.service.ts
+++ b/src/app/data-explorer/specification-submission/services/specification-submission.service.ts
@@ -24,15 +24,14 @@ import { of } from 'rxjs/internal/observable/of';
 import { switchMap } from 'rxjs/internal/operators/switchMap';
 import { SubmissionStateService } from './submission-state.service';
 import { CreateDataRequestStep } from '../submission-steps/create-data-request.step';
-import { ISubmissionStep, StepResult } from '../type-declarations/submission.resource';
-import { ToastrService } from 'ngx-toastr';
-import { NoProjectsFoundError } from '../type-declarations/submission.custom-errors';
+import { ISubmissionStep, StepName, StepResult } from '../type-declarations/submission.resource';
 import { GenerateSqlStep } from '../submission-steps/generate-sql.step';
 import { AttachSqlStep } from '../submission-steps/attach-sql.step';
 import { GeneratePdfStep } from '../submission-steps/generate-pdf.step';
 import { AttachPdfStep } from '../submission-steps/attach-pdf.step';
 import { SubmitRequestStep } from '../submission-steps/submit-request.step';
 import { BroadcastService } from 'src/app/core/broadcast.service';
+import { DialogService } from '../../dialog.service';
 
 @Injectable({
   providedIn: 'root',
@@ -42,7 +41,7 @@ export class SpecificationSubmissionService {
 
   constructor(
     private stateService: SubmissionStateService,
-    private toast: ToastrService,
+    private dialogService: DialogService,
     private broadcastService: BroadcastService,
     private createDataRequestStep: CreateDataRequestStep,
     private generateSqlStep: GenerateSqlStep,
@@ -94,16 +93,16 @@ export class SpecificationSubmissionService {
             this.stateService.set({ ...stepResult.result });
           }),
           catchError((error: Error) => {
-            console.error('Error running step', step.name, error);
-            const errorHandled = this.handleSubmissionError(error);
-            if (errorHandled) {
-              const cancelResult = {
-                result: { cancel: true },
-              } as StepResult;
-              this.stateService.set({ ...cancelResult.result });
-              return EMPTY;
-            }
-            throw error;
+            this.handleSubmissionError(error, step.name);
+
+            // Cancel the submission at this step if an error occurs.
+            const cancelResult = {
+              result: { cancel: true },
+            } as StepResult;
+            this.stateService.set({ ...cancelResult.result });
+
+            // Complete the step with cancel set.
+            return EMPTY;
           })
         );
       }),
@@ -116,12 +115,17 @@ export class SpecificationSubmissionService {
     );
   }
 
-  // Toast is probably not the way we want to deal with errors. But having a generic error handler is a good idea.
-  private handleSubmissionError(error: Error) {
-    if (error instanceof NoProjectsFoundError) {
-      this.toast.error(error.message);
-      return true;
-    }
-    return false;
+  private handleSubmissionError(error: Error, stepName: StepName): void {
+    // Log the error to the console.
+    console.error(`Error running step ${stepName}. Step failed with error message: ${error}`);
+
+    const errorMessage = this.buildErrorMessage(stepName);
+    this.dialogService.openSimple({ heading: 'Submission Error', message: errorMessage });
+  }
+
+  private buildErrorMessage(stepName: StepName): string {
+    return `<p>Submission Step <b>${stepName}</b> failed.</p>
+    <p>Please press the Submit button again to submit your data specification.
+    If you keep seeing this message then please contact Mauro administrators for help.</p>`;
   }
 }

--- a/src/app/data-explorer/specification-submission/services/submission-state.service.ts
+++ b/src/app/data-explorer/specification-submission/services/submission-state.service.ts
@@ -29,6 +29,10 @@ export class SubmissionStateService {
     this._state = {} as ISubmissionState;
   }
 
+  clear(): void {
+    this._state = {} as ISubmissionState;
+  }
+
   get(): ISubmissionState {
     return { ...this._state };
   }

--- a/src/app/data-explorer/specification-submission/submission-steps/generate-sql.step.ts
+++ b/src/app/data-explorer/specification-submission/submission-steps/generate-sql.step.ts
@@ -33,7 +33,7 @@ import { BroadcastService } from 'src/app/core/broadcast.service';
   providedIn: 'root',
 })
 export class GenerateSqlStep implements ISubmissionStep {
-  name: StepName = StepName.GeneratePdfFile;
+  name: StepName = StepName.GenerateSqlFile;
 
   constructor(
     private fileGenerationStepService: FileGenerationStepService,

--- a/src/app/data-explorer/specification-submission/type-declarations/submission.custom-errors.ts
+++ b/src/app/data-explorer/specification-submission/type-declarations/submission.custom-errors.ts
@@ -16,13 +16,16 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
+
+export const DEFAULT_ERROR_MESSAGE =
+  'Please try submitting your data specification again by pressing the Submit button. If the issue persists, contact the Mauro administrators for assistance.';
+
 export const DEFAULT_NO_PROJECTS_MESSAGE =
-  'You do not have any projects to submit this data request for. ';
+  'You are not an active member of any projects and every data specification submission must include the project you are submitting it for. Please either submit a Help request to join an existing project or submit a New Project request before submitting this data specificaiton.';
 
 export class NoProjectsFoundError extends Error {
   constructor(message?: string) {
     super(message ?? DEFAULT_NO_PROJECTS_MESSAGE);
     Object.setPrototypeOf(this, NoProjectsFoundError.prototype);
-    this.name = 'NoProjectsFoundError';
   }
 }

--- a/src/app/shared/loading-spinner/loading-spinner.component.html
+++ b/src/app/shared/loading-spinner/loading-spinner.component.html
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<div class="mdm-spinner-container">
+<div [ngClass]="spinnerContainerCssClassMap">
   <mat-spinner [diameter]="diameter" [color]="color"></mat-spinner>
   <div [className]="color">{{ caption }}</div>
 </div>

--- a/src/app/shared/loading-spinner/loading-spinner.component.scss
+++ b/src/app/shared/loading-spinner/loading-spinner.component.scss
@@ -42,12 +42,15 @@ $accentColor: mat.get-color-from-palette($accent-palette, "text");
   color: $primaryColor;
 }
 
-.mdm-spinner-container {
+.mdm-spinner-container--fill {
   display: flex;
   justify-content: center;
   align-items: center;
   flex-direction: column;
   position: fixed;
+  font-weight: bold;
+  text-align: center;
+  z-index: 100;
   top: 50vh;
   left: 50vw;
   height: 100vh;
@@ -55,7 +58,21 @@ $accentColor: mat.get-color-from-palette($accent-palette, "text");
   margin-left: -50vw;
   margin-top: -50vh;
   background-color: rgba(255, 255, 255, 0.5);
+}
+
+.mdm-spinner-container--centre {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  position: fixed;
   font-weight: bold;
   text-align: center;
   z-index: 100;
+  top: 50%;
+  left: 50%;
+  height: 30vh;
+  width: 30vw;
+  transform: translate(-50%, -50%);
+  background-color: rgba(255, 255, 255);
 }

--- a/src/app/shared/loading-spinner/loading-spinner.component.ts
+++ b/src/app/shared/loading-spinner/loading-spinner.component.ts
@@ -28,4 +28,16 @@ export class LoadingSpinnerComponent {
   @Input() color: ThemePalette = 'primary';
   @Input() diameter = 50;
   @Input() caption = 'Loading ...';
+  @Input() fillviewport = true;
+
+  /**
+   * Get the CSS class to use to size the spinner container, mapped to an object that can be applied to
+   * the NgClass directive.
+   */
+  get spinnerContainerCssClassMap() {
+    return {
+      'mdm-spinner-container--fill': this.fillviewport,
+      'mdm-spinner-container--centre': !this.fillviewport,
+    };
+  }
 }

--- a/src/app/testing/stubs/data-specification-submission/submission-state.stub.ts
+++ b/src/app/testing/stubs/data-specification-submission/submission-state.stub.ts
@@ -20,17 +20,23 @@ import { ISubmissionState } from '../../../data-explorer/specification-submissio
 
 export type StateServiceSetFn = (state: Partial<ISubmissionState>) => void;
 export type StateServiceSetMockedFn = jest.MockedFunction<StateServiceSetFn>;
+
 export type StateServiceGetFn = () => ISubmissionState;
 export type StateServiceGetMockedFn = jest.MockedFunction<StateServiceGetFn>;
+
 export type StateServiceGetStepInputFromShapeFn = (
   shape: (keyof ISubmissionState)[]
 ) => Partial<ISubmissionState>;
 export type StateServiceGetStepInputFromShapeMockedFn =
   jest.MockedFunction<StateServiceGetStepInputFromShapeFn>;
 
+export type StateServiceClearFn = () => void;
+export type StateServiceClearMockedFn = jest.MockedFunction<StateServiceClearFn>;
+
 export interface StateServiceStub {
   set: StateServiceSetMockedFn;
   get: StateServiceGetMockedFn;
+  clear: StateServiceClearMockedFn;
   getStepInputFromShape: StateServiceGetStepInputFromShapeMockedFn;
 }
 
@@ -38,6 +44,7 @@ export const createStateServiceStub = (): StateServiceStub => {
   return {
     set: jest.fn() as StateServiceSetMockedFn,
     get: jest.fn() as StateServiceGetMockedFn,
+    clear: jest.fn() as StateServiceClearMockedFn,
     getStepInputFromShape: jest.fn() as StateServiceGetStepInputFromShapeMockedFn,
   };
 };


### PR DESCRIPTION
- Add `SimpleDialogComponent` for generic dialog messages. 
- Add a test checking the dialog is opened if an error is thrown during a test. 

Simplest way to test is to manually throw an error in one of the existing steps. I suggest a later step just to see how the UX flows from working to failure. 

closes #412 