### PR TITLE
gh-399 - ensure new version only created upon clicking 'yes'.

### DIFF
--- a/src/app/pages/my-data-specification-detail/my-data-specification-detail.component.ts
+++ b/src/app/pages/my-data-specification-detail/my-data-specification-detail.component.ts
@@ -568,7 +568,8 @@ export class MyDataSpecificationDetailComponent implements OnInit, OnDestroy {
       .pipe(
         switchMap(
           (okCancelDialogResponse?: OkCancelDialogResponse): Observable<DataModelDetail> => {
-            if (!okCancelDialogResponse || !this.dataSpecification) {
+            // If dataSpec or dialogResponse undefined, or if user clicked No, return EMPTY
+            if (okCancelDialogResponse?.result === false || !this.dataSpecification) {
               return EMPTY;
             }
 
@@ -591,7 +592,7 @@ export class MyDataSpecificationDetailComponent implements OnInit, OnDestroy {
         finalize(() => this.broadcastService.loading({ isLoading: false }))
       )
       .subscribe((newVersion?) => {
-        this.stateRouter.navigateTo(['/dataSpecifications', newVersion.id]);
+        this.stateRouter.navigateTo(['/dataSpecifications', newVersion?.id]);
       });
   }
 


### PR DESCRIPTION
- Make use of the dialogResponse.result instead of just checking the response object is initialized.

closes #399 