### PR TITLE
gh-372 - auto add core table elements during copy

### DIFF
--- a/src/app/data-explorer/core-table-profile.service.spec.ts
+++ b/src/app/data-explorer/core-table-profile.service.spec.ts
@@ -101,7 +101,7 @@ describe('CoreTableProfileService', () => {
         a: expectedResult,
       });
 
-      const actual$ = service.getQueryBuilderCoreTableProfile(rootDataModel as DataModel);
+      const actual$ = service.getQueryBuilderCoreTableProfile(rootDataModel.id);
 
       expect(actual$).toBeObservable(expected$);
     });
@@ -159,7 +159,7 @@ describe('CoreTableProfileService', () => {
         a: expectedFrameResults,
       });
 
-      const actual$ = service.getQueryBuilderCoreTableProfile(rootDataModel as DataModel);
+      const actual$ = service.getQueryBuilderCoreTableProfile(rootDataModel.id);
 
       expect(actual$).toBeObservable(expected$);
     });

--- a/src/app/data-explorer/core-table-profile.service.ts
+++ b/src/app/data-explorer/core-table-profile.service.ts
@@ -22,6 +22,7 @@ import {
   DataModel,
   Profile,
   ProfileValidationErrorList,
+  Uuid,
 } from '@maurodatamapper/mdm-resources';
 import { Observable, of } from 'rxjs';
 import { ProfileService } from '../mauro/profile.service';
@@ -32,22 +33,21 @@ import { ProfileService } from '../mauro/profile.service';
 export class CoreTableProfileService {
   private readonly queryBuilderProfileNamespace =
     'uk.ac.ox.softeng.maurodatamapper.plugins.explorer.querybuilder';
-  private readonly queryBuilderCoreTableProfileName =
-    'QueryBuilderCoreTableProfileProviderService';
+  private readonly queryBuilderCoreTableProfileName = 'QueryBuilderCoreTableProfileProviderService';
 
   constructor(private profileService: ProfileService) {}
 
   public getQueryBuilderCoreTableProfile(
-    dataModel: DataModel
+    dataModelId: Uuid | undefined
   ): Observable<Profile | undefined> {
     const requestOptions = {
       handleGetErrors: false,
     };
 
-    if (dataModel.id) {
+    if (dataModelId) {
       return this.profileService.get(
         CatalogueItemDomainType.DataModel,
-        dataModel.id,
+        dataModelId,
         this.queryBuilderProfileNamespace,
         this.queryBuilderCoreTableProfileName,
         requestOptions

--- a/src/app/data-explorer/data-specification.service.ts
+++ b/src/app/data-explorer/data-specification.service.ts
@@ -870,7 +870,7 @@ export class DataSpecificationService {
   ): Observable<[DataModelDetail, Profile | undefined]> {
     return forkJoin([
       of(dataModelDetail),
-      this.coreTableProfileService.getQueryBuilderCoreTableProfile(rootDataModel),
+      this.coreTableProfileService.getQueryBuilderCoreTableProfile(rootDataModel.id),
     ]);
   }
 

--- a/src/app/data-explorer/query-builder-wrapper.service.ts
+++ b/src/app/data-explorer/query-builder-wrapper.service.ts
@@ -317,7 +317,7 @@ export class QueryBuilderWrapperService {
   private getCoreTableProfile(
     dataModel: DataModel
   ): Observable<[Profile, ProfileValidationErrorList] | undefined> {
-    return this.coreTableProfileService.getQueryBuilderCoreTableProfile(dataModel).pipe(
+    return this.coreTableProfileService.getQueryBuilderCoreTableProfile(dataModel.id).pipe(
       switchMap((coreTableProfile: Profile | undefined) => {
         if (!coreTableProfile) {
           return of(undefined);

--- a/src/app/mauro/data-specification-research-plugin.service.ts
+++ b/src/app/mauro/data-specification-research-plugin.service.ts
@@ -22,6 +22,7 @@ import {
   DataModelDetail,
   DataModelDetailResponse,
   DataModelIndexResponse,
+  MdmResponse,
   Uuid,
 } from '@maurodatamapper/mdm-resources';
 import { forkJoin, map, Observable, of, switchMap } from 'rxjs';
@@ -70,5 +71,11 @@ export class DataSpecificationResearchPluginService {
         return forkJoin(dataSpecification$);
       })
     );
+  }
+
+  getRequiredCoreTableDataElementIds(dataElementsIds: Uuid[]): Observable<Uuid[]> {
+    return this.endpoints.pluginResearch
+      .getRequiredCoreTableDataElementIds(dataElementsIds)
+      .pipe(map((response: MdmResponse<Uuid[]>) => response.body));
   }
 }

--- a/src/app/mauro/plugins/plugin-research.resource.ts
+++ b/src/app/mauro/plugins/plugin-research.resource.ts
@@ -154,4 +154,16 @@ export class MdmPluginResearchResource extends MdmResource {
     const url = `${this.apiEndpoint}/explorer/getLatestModelDataSpecifications`;
     return this.simpleGet(url);
   }
+
+  /**
+   * `HTTP POST` - Get the required data element ids corresponding to the primary key of the
+   * core table (datamodel) and the foreign keys in the parent tables of the supplied data elements.
+   *
+   * @param data The list of data model IDs to get the required core table related data elements for.
+   *
+   */
+  getRequiredCoreTableDataElementIds(data: Uuid[], options?: RequestSettings) {
+    const url = `${this.apiEndpoint}/explorer/getRequiredCoreTableDataElementIds`;
+    return this.simplePost(url, data, options);
+  }
 }

--- a/src/app/shared/data-element-in-data-specification/data-element-in-data-specification.component.ts
+++ b/src/app/shared/data-element-in-data-specification/data-element-in-data-specification.component.ts
@@ -183,7 +183,7 @@ export class DataElementInDataSpecificationComponent implements OnInit, OnDestro
                 (de) => de.id
               );
             }
-            return this.endpoints.dataModel.copySubset(
+            return this.dataModelService.copySubset(
               transposedDataElements[0].model,
               targetDataModelId,
               datamodelSubsetPayload

--- a/src/app/testing/stubs/data-specification-research-plugin.stub.ts
+++ b/src/app/testing/stubs/data-specification-research-plugin.stub.ts
@@ -28,10 +28,13 @@ export type GetLatestModelDataSpecificationsMockedFn =
 
 export type ListSharedDataSpecificationsFn = () => Observable<DataSpecification[]>;
 
+export type GetRequiredCoreTableDataElementIdsFn = (dataElementsIds: Uuid[]) => Observable<Uuid[]>;
+
 export interface DataSpecificationResearchPluginServiceStub {
   finaliseDataSpecification: jest.MockedFunction<ResearchPluginSubmitDataSpecificationFn>;
   getLatestModelDataSpecifications: GetLatestModelDataSpecificationsMockedFn;
   listSharedDataSpecifications: jest.MockedFunction<ListSharedDataSpecificationsFn>;
+  getRequiredCoreTableDataElementIds: jest.MockedFunction<GetRequiredCoreTableDataElementIdsFn>;
 }
 
 export const createDataSpecificationResearchPluginServiceStub =
@@ -42,5 +45,7 @@ export const createDataSpecificationResearchPluginServiceStub =
       getLatestModelDataSpecifications: jest.fn() as GetLatestModelDataSpecificationsMockedFn,
       listSharedDataSpecifications:
         jest.fn() as jest.MockedFunction<ListSharedDataSpecificationsFn>,
+      getRequiredCoreTableDataElementIds:
+        jest.fn() as jest.MockedFunction<GetRequiredCoreTableDataElementIdsFn>,
     };
   };


### PR DESCRIPTION
Ensure that any time a data specification is copied or created that the primary key data element of the core table and any foreign keys to the core table from selected dataclasses are also copied over. This ensures the cohort/data queries function properly. 

- Add plumbing to connect to newly added mdm-plugin-explorer endpoint
- Update tests to ensure duplicates aren't copied/added 
- Prefer dataModel.id over full dataModel object reference for method parameter. 

Needs to be tested alongside: maurodatamapper-plugins/mdm-plugin-explorer#49

closes #372 