### PR TITLE
gh-446: Set mdm-resources version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@angular/platform-browser-dynamic": "14.2.12",
     "@angular/router": "14.2.12",
     "@fortawesome/fontawesome-free": "6.3.0",
-    "@maurodatamapper/mdm-resources": "5.3.0",
+    "@maurodatamapper/mdm-resources": "5.4.0-SNAPSHOT",
     "@maurodatamapper/sde-resources": "0.0.1",
     "chart.js": "3.8.0",
     "moment": "2.29.4",


### PR DESCRIPTION
closes #446 

Updated to pull the correct mdm-resources version.