### PR TITLE
gh-475-rename-requestsListConfig -> requestFilterConfig

### DIFF
--- a/src/app/pages/sde-main/sde-main.component.ts
+++ b/src/app/pages/sde-main/sde-main.component.ts
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Component, OnInit } from '@angular/core';
-import { RequestsListMode } from '@maurodatamapper/sde-resources';
+import { RequestFilterMode } from '@maurodatamapper/sde-resources';
 import { SecurityService } from 'src/app/security/security.service';
 
 @Component({
@@ -26,7 +26,7 @@ import { SecurityService } from 'src/app/security/security.service';
 })
 export class SdeMainComponent implements OnInit {
   signedIn = false;
-  requestsNeedingApprovalListConfig: RequestsListMode = RequestsListMode.CanAuthorise;
+  requestsNeedingApprovalListConfig: RequestFilterMode = RequestFilterMode.CanAuthorise;
 
   constructor(private security: SecurityService) {}
 

--- a/src/app/secure-data-environment/components/sde-requests/sde-requests.component.ts
+++ b/src/app/secure-data-environment/components/sde-requests/sde-requests.component.ts
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Component, OnInit } from '@angular/core';
-import { RequestsListMode, MembershipEndpointsResearcher } from '@maurodatamapper/sde-resources';
+import { RequestFilterMode, MembershipEndpointsResearcher } from '@maurodatamapper/sde-resources';
 import { forkJoin } from 'rxjs';
 
 @Component({
@@ -28,8 +28,8 @@ import { forkJoin } from 'rxjs';
 export class SdeRequestsComponent implements OnInit {
   canAuthorise = false;
 
-  requestsListConfig: RequestsListMode = RequestsListMode.CreatedByMe;
-  requestsNeedingApprovalListConfig: RequestsListMode = RequestsListMode.CanAuthorise;
+  requestsListConfig: RequestFilterMode = RequestFilterMode.CreatedByMe;
+  requestsNeedingApprovalListConfig: RequestFilterMode = RequestFilterMode.CanAuthorise;
 
   constructor(private membershipEndpointsResearcher: MembershipEndpointsResearcher) {}
 

--- a/src/app/secure-data-environment/pages/departments/departments.component.ts
+++ b/src/app/secure-data-environment/pages/departments/departments.component.ts
@@ -21,7 +21,7 @@ import {
   Department,
   DepartmentMemberService,
   ListColumn,
-  RequestsListMode,
+  RequestFilterMode,
   UserDepartmentDTO,
   Uuid,
 } from '@maurodatamapper/sde-resources';
@@ -41,8 +41,8 @@ export class DepartmentsComponent implements OnInit {
   userHasDepartments = true;
   userIsApproverForSelectedDepartment = false;
 
-  requestsNeedingApprovalListConfig: RequestsListMode = RequestsListMode.CanAuthorise;
-  myRequestsListConfig: RequestsListMode = RequestsListMode.MyDepartmentRequests;
+  requestsNeedingApprovalListConfig: RequestFilterMode = RequestFilterMode.CanAuthorise;
+  myRequestsListConfig: RequestFilterMode = RequestFilterMode.MyDepartmentRequests;
 
   constructor(
     private sdeDepartmentService: SdeDepartmentService,


### PR DESCRIPTION
closes #gh-475
see: https://github.com/MauroDataMapper/sde-admin-ui/pull/209
and https://github.com/MauroDataMapper/sde-resources/pull/163 for details

from Issues:

When implementing the kanban board, I decoupled the request list filters (now RequestFilterComponent) from the rest of the component. I renamed the config enum to better reflect what it now does (From RequestsListMode => RequestFilterMode). I forgot to update this on mdm-explorer. This will fix the build issue when used with sde-resources https://github.com/MauroDataMapper/mdm-explorer/issues/162 (https://github.com/MauroDataMapper/sde-resources/pull/163/

I considered reverting the name change but I decided to update this as I believe the old name no longer reflects which component its now used in and I want to keep to followable.