### PR TITLE
Feature/450 org membership requirement for routes

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -24,6 +24,7 @@ SPDX-License-Identifier: Apache-2.0
       [signInLink]="signInLink"
       [signedInUser]="signedInUser"
       [signedInUserProfileImageSrc]="signedInUserProfileImageSrc"
+      [organisationMember]="organisationMember"
       [rightLinks]="headerRightLinks"
       [accountLink]="accountLink"
       [draftDataSpecificationCount]="draftDataSpecificationsCount"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -255,10 +255,10 @@ export class AppComponent implements OnInit, OnDestroy {
     this.broadcast
       .sdeOnUserOrganisationStatusUpdated()
       .pipe(takeUntil(this.unsubscribe$))
-      .subscribe(() => this.setControlValues(this.userDetails.sdeGetUserOrganisationMembership()));
+      .subscribe(() => this.setControlValues());
 
     this.signedInUser = user;
-
+    this.setControlValues();
     this.subscribeHttpErrorEvent('http-not-authorized', '/not-authorized');
     this.subscribeHttpErrorEvent('http-not-found', '/not-found');
     this.subscribeHttpErrorEvent('http-not-implemented', '/not-implemented');
@@ -333,6 +333,10 @@ export class AppComponent implements OnInit, OnDestroy {
     this.signedInUserProfileImageSrc = user
       ? `${environment.mauroCoreEndpoint}/catalogueUsers/${user.id}/image`
       : undefined;
+
+    if (user) {
+      this.setControlValues();
+    }
   }
 
   private getDraftDataSpecificationCount() {
@@ -411,8 +415,8 @@ export class AppComponent implements OnInit, OnDestroy {
       });
   }
 
-  private setControlValues(isOrganisationMember: boolean) {
-    this.organisationMember = isOrganisationMember;
+  private setControlValues() {
+    this.organisationMember = this.userDetails.sdeGetUserOrganisationMembership() ?? false;
     // set other values here
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -64,6 +64,8 @@ export class AppComponent implements OnInit, OnDestroy {
 
   signedInUser?: UserDetails | null;
 
+  organisationMember?: boolean | null;
+
   logoLink: HeaderImageLink = {
     label: 'Secure Data Environment User Portal',
     routerLink: '',
@@ -102,12 +104,12 @@ export class AppComponent implements OnInit, OnDestroy {
     {
       label: 'Browse',
       routerLink: '/browse',
-      onlySignedIn: true,
+      onlyOrganisationMember: true,
     },
     {
       label: 'Search',
       routerLink: '/search',
-      onlySignedIn: true,
+      onlyOrganisationMember: true,
     },
     /* Temporarily removed
     {
@@ -134,6 +136,7 @@ export class AppComponent implements OnInit, OnDestroy {
       routerLink: '/bookmarks',
       defaultImageSrc: '',
       defaultRightImageSrc: '',
+      onlyOrganisationMember: true,
     },
   ];
 
@@ -141,6 +144,7 @@ export class AppComponent implements OnInit, OnDestroy {
     label: 'My Data Specifications',
     routerLink: '/dataSpecifications',
     arrow: 'angle-down',
+    onlyOrganisationMember: true,
   };
 
   signInLink: HeaderLink = {
@@ -247,6 +251,11 @@ export class AppComponent implements OnInit, OnDestroy {
           (this.draftDataSpecificationsCount = draftDataSpecificationsCount)
       );
     }
+
+    this.broadcast
+      .sdeOnUserOrganisationStatusUpdated()
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe(() => this.setControlValues(this.userDetails.sdeGetUserOrganisationMembership()));
 
     this.signedInUser = user;
 
@@ -400,5 +409,10 @@ export class AppComponent implements OnInit, OnDestroy {
         this.toastr.info('Your session has expired! Please sign in.');
         this.signOutUser();
       });
+  }
+
+  private setControlValues(isOrganisationMember: boolean) {
+    this.organisationMember = isOrganisationMember;
+    // set other values here
   }
 }

--- a/src/app/core/broadcast.service.ts
+++ b/src/app/core/broadcast.service.ts
@@ -30,6 +30,8 @@ export type BroadcastEvent =
   | 'http-server-error'
   | 'user-signed-in'
   | 'user-signed-out'
+  | 'sde-user-signed-in'
+  | 'sde-user-signed-out'
   | 'sign-out-user'
   | 'data-specification-added'
   | 'data-specification-finalised'
@@ -98,6 +100,17 @@ export class BroadcastService {
    */
   onUserSignedIn(): Observable<UserDetails> {
     return this.on<UserDetails>('user-signed-in');
+  }
+
+  /**
+   * pair of methods to alert that the sdeUser has signed in to the sde system
+   */
+  sdeOnUserOrganisationStatusUpdated(): Observable<boolean> {
+    return this.on<boolean>('sde-user-signed-in');
+  }
+
+  sdeUserOrganisationStatusUpdated(status: boolean) {
+    this.dispatch<boolean>('sde-user-signed-in', status);
   }
 
   loading(payload: LoadingBroadcastPayload) {

--- a/src/app/data-explorer/specification-submission/services/specification-submission.service.ts
+++ b/src/app/data-explorer/specification-submission/services/specification-submission.service.ts
@@ -132,18 +132,16 @@ export class SpecificationSubmissionService {
       )
     );
 
-    const newProjectEnquiryRequests$ = this.requestsService
-      .listDraftNewProjectEnquiryRequests()
-      .pipe(
-        map((requests: SdeRequest[]) =>
-          requests.map<IdNamePair>((request) => {
-            return {
-              id: request.id,
-              name: request.title,
-            };
-          })
-        )
-      );
+    const newProjectEnquiryRequests$ = this.requestsService.listDraftNewProjectRequests().pipe(
+      map((requests: SdeRequest[]) =>
+        requests.map<IdNamePair>((request) => {
+          return {
+            id: request.id,
+            name: request.title,
+          };
+        })
+      )
+    );
 
     return this.researcherRequestEndpoints.getRequestForDataSpecification(specificationId).pipe(
       // First map operation to extract `request.id`

--- a/src/app/pages/pages.routes.ts
+++ b/src/app/pages/pages.routes.ts
@@ -44,6 +44,7 @@ import { TemplateDataSpecificationDetailComponent } from './template-data-specif
 import { SdeMainComponent } from './sde-main/sde-main.component';
 import { SdeAuthenticationFinalizeComponent } from './sde-authentication-finalize/sde-authentication-finalize.component';
 import { UserRegistrationComponent } from './user-registration/user-registration.component';
+import { OrganisationMemberGuard } from '../shared/guards/organisation-member.guard';
 
 export const buildStaticContentRoute = (path: string, staticAssetPath: string): Route => {
   return {
@@ -131,17 +132,17 @@ export const routes: Route[] = [
   {
     path: 'browse',
     component: BrowseComponent,
-    canActivate: [AuthorizedGuard],
+    canActivate: [OrganisationMemberGuard],
   },
   {
     path: 'search',
     component: SearchComponent,
-    canActivate: [AuthorizedGuard],
+    canActivate: [OrganisationMemberGuard],
   },
   {
     path: 'search/listing',
     component: SearchListingComponent,
-    canActivate: [AuthorizedGuard],
+    canActivate: [OrganisationMemberGuard],
   },
   {
     path: 'account',
@@ -156,7 +157,7 @@ export const routes: Route[] = [
   {
     path: 'bookmarks',
     component: MyBookmarksComponent,
-    canActivate: [AuthorizedGuard],
+    canActivate: [OrganisationMemberGuard],
   },
   {
     path: 'dataElement/:dataModelId/:dataClassId/:dataElementId',
@@ -166,28 +167,28 @@ export const routes: Route[] = [
   {
     path: 'dataSpecifications',
     component: MyDataSpecificationsComponent,
-    canActivate: [AuthorizedGuard],
+    canActivate: [OrganisationMemberGuard],
   },
   {
     path: 'dataSpecifications/:dataSpecificationId/queries/:queryType',
     component: DataSpecificationQueryComponent,
-    canActivate: [AuthorizedGuard],
+    canActivate: [OrganisationMemberGuard],
     canDeactivate: [ModelPageDirtyGuard],
   },
   {
     path: 'dataSpecifications/:dataSpecificationId',
     component: MyDataSpecificationDetailComponent,
-    canActivate: [AuthorizedGuard],
+    canActivate: [OrganisationMemberGuard],
   },
   {
     path: 'templates',
     component: TemplateDataSpecificationsComponent,
-    canActivate: [AuthorizedGuard],
+    canActivate: [OrganisationMemberGuard],
   },
   {
     path: 'templates/:dataSpecificationId',
     component: TemplateDataSpecificationDetailComponent,
-    canActivate: [AuthorizedGuard],
+    canActivate: [OrganisationMemberGuard],
   },
   {
     path: 'sde',

--- a/src/app/pages/sde-authentication-finalize/sde-authentication-finalize.component.spec.ts
+++ b/src/app/pages/sde-authentication-finalize/sde-authentication-finalize.component.spec.ts
@@ -25,7 +25,9 @@ import {
 import { createStateRouterStub } from 'src/app/testing/stubs/state-router.stub';
 import { StateRouterService } from 'src/app/core/state-router.service';
 import { UserDetailsService } from 'src/app/security/user-details.service';
-import { ResearchUser } from '@maurodatamapper/sde-resources';
+import { ResearchUser, SdeUserService } from '@maurodatamapper/sde-resources';
+import { of } from 'rxjs';
+import { BroadcastService } from 'src/app/core/broadcast.service';
 
 describe('SdeAuthenticationFinalizeComponent', () => {
   let harness: ComponentHarness<SdeAuthenticationFinalizeComponent>;
@@ -34,6 +36,13 @@ describe('SdeAuthenticationFinalizeComponent', () => {
   const userDetailsStub = {
     setSdeResearchUser: jest.fn(),
     clearSdeResearchUser: jest.fn(),
+    sdeSetUserOrganisationMembership: jest.fn(),
+  };
+  const sdeUserServiceStub = {
+    isSdeUserAMemberOfAnOrganisation: jest.fn(),
+  };
+  const broadcastStub = {
+    sdeUserOrganisationStatusUpdated: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -47,6 +56,14 @@ describe('SdeAuthenticationFinalizeComponent', () => {
           provide: UserDetailsService,
           useValue: userDetailsStub,
         },
+        {
+          provide: SdeUserService,
+          useValue: sdeUserServiceStub,
+        },
+        {
+          provide: BroadcastService,
+          useValue: broadcastStub,
+        },
       ],
     });
   });
@@ -55,12 +72,17 @@ describe('SdeAuthenticationFinalizeComponent', () => {
     stateRouterStub.navigateTo.mockClear();
     userDetailsStub.clearSdeResearchUser.mockClear();
     userDetailsStub.setSdeResearchUser.mockClear();
+    userDetailsStub.sdeSetUserOrganisationMembership.mockClear();
+    sdeUserServiceStub.isSdeUserAMemberOfAnOrganisation.mockClear();
+    broadcastStub.sdeUserOrganisationStatusUpdated.mockClear();
   });
 
   describe('sign-in-success', () => {
-    it('should get user details then redirect', () => {
+    it('should get user details, set org membership, broadcast status, and redirect', fakeAsync(() => {
       const userDetailsSpy = jest.spyOn(userDetailsStub, 'setSdeResearchUser');
       const stateRouterSpy = jest.spyOn(stateRouterStub, 'navigateToKnownPath');
+      const sdeUserServiceSpy = jest.spyOn(sdeUserServiceStub, 'isSdeUserAMemberOfAnOrganisation');
+      const broadcastSpy = jest.spyOn(broadcastStub, 'sdeUserOrganisationStatusUpdated');
 
       const expectedUser = {
         id: '1234',
@@ -68,11 +90,18 @@ describe('SdeAuthenticationFinalizeComponent', () => {
         isDeleted: false,
       } as ResearchUser;
 
+      sdeUserServiceSpy.mockReturnValue(of(true));
+
       harness.component.signInSuccess(expectedUser);
 
+      tick();
+
       expect(userDetailsSpy).toHaveBeenCalledWith(expectedUser);
+      expect(sdeUserServiceSpy).toHaveBeenCalledWith(expectedUser.id);
+      expect(userDetailsStub.sdeSetUserOrganisationMembership).toHaveBeenCalledWith(true);
+      expect(broadcastSpy).toHaveBeenCalledWith(true);
       expect(stateRouterSpy).toHaveBeenCalledWith('/dashboard');
-    });
+    }));
   });
 
   describe('sign-out', () => {
@@ -89,3 +118,4 @@ describe('SdeAuthenticationFinalizeComponent', () => {
     }));
   });
 });
+

--- a/src/app/pages/sde-authentication-finalize/sde-authentication-finalize.component.ts
+++ b/src/app/pages/sde-authentication-finalize/sde-authentication-finalize.component.ts
@@ -17,7 +17,8 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Component } from '@angular/core';
-import { ResearchUser, User } from '@maurodatamapper/sde-resources';
+import { ResearchUser, SdeUserService, User } from '@maurodatamapper/sde-resources';
+import { BroadcastService } from 'src/app/core/broadcast.service';
 import { StateRouterService } from 'src/app/core/state-router.service';
 import { UserDetailsService } from 'src/app/security/user-details.service';
 
@@ -28,13 +29,20 @@ import { UserDetailsService } from 'src/app/security/user-details.service';
 })
 export class SdeAuthenticationFinalizeComponent {
   constructor(
+    private broadcast: BroadcastService,
     private userDetails: UserDetailsService,
+    private sdeUserService: SdeUserService,
     private stateRouter: StateRouterService
   ) {}
 
   signInSuccess(user: User | ResearchUser) {
     this.userDetails.setSdeResearchUser(user as ResearchUser);
-    this.stateRouter.navigateToKnownPath('/dashboard');
+    // sets the user current org membership status
+    this.sdeUserService.isSdeUserAMemberOfAnOrganisation(user.id).subscribe((isMember) => {
+      this.userDetails.sdeSetUserOrganisationMembership(isMember);
+      this.broadcast.sdeUserOrganisationStatusUpdated(isMember);
+      this.stateRouter.navigateToKnownPath('/dashboard');
+    });
   }
 
   signOut() {

--- a/src/app/pages/sde-main/sde-main.component.ts
+++ b/src/app/pages/sde-main/sde-main.component.ts
@@ -16,7 +16,8 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { Component, OnInit } from '@angular/core';
+import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
+import { MatTabChangeEvent, MatTabGroup } from '@angular/material/tabs';
 import { MembershipEndpointsResearcher, RequestFilterMode } from '@maurodatamapper/sde-resources';
 import { SecurityService } from 'src/app/security/security.service';
 
@@ -24,15 +25,18 @@ import { SecurityService } from 'src/app/security/security.service';
   templateUrl: './sde-main.component.html',
   styleUrls: ['./sde-main.component.scss'],
 })
-export class SdeMainComponent implements OnInit {
+export class SdeMainComponent implements OnInit, AfterViewInit {
   signedIn = false;
   restrictAccess = true;
   requestsNeedingApprovalListConfig: RequestFilterMode = RequestFilterMode.CanAuthorise;
+  currentTabIndex = 1;
 
   constructor(
     private security: SecurityService,
     private membershipEndpointsResearcher: MembershipEndpointsResearcher
   ) {}
+
+  ngAfterViewInit(): void {}
 
   ngOnInit(): void {
     this.signedIn = this.security.isSignedInToSde();
@@ -41,5 +45,13 @@ export class SdeMainComponent implements OnInit {
         this.restrictAccess = organisation === null;
       });
     }
+  }
+
+  getSelectedIndex(): number {
+    return this.currentTabIndex;
+  }
+
+  onTabChange(event: MatTabChangeEvent) {
+    this.currentTabIndex = event.index;
   }
 }

--- a/src/app/security/guards/authorized.guard.spec.ts
+++ b/src/app/security/guards/authorized.guard.spec.ts
@@ -24,55 +24,57 @@ import { AUTHORIZATION_REDIRECT_URL } from '../security.types';
 
 import { AuthorizedGuard } from './authorized.guard';
 
-describe('AuthorizedGuard', () => {
-  let guard: AuthorizedGuard;
 
-  const redirectUrl = 'some/where/else';
-  const securityStub = createSecurityServiceStub();
+    describe('AuthorizedGuard', () => {
+      let guard: AuthorizedGuard;
 
-  const routerStub = {
-    parseUrl: jest.fn(),
-  };
+      const redirectUrl = 'some/where/else';
+      const securityStub = createSecurityServiceStub();
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [
-        {
-          provide: SecurityService,
-          useValue: securityStub,
-        },
-        {
-          provide: Router,
-          useValue: routerStub,
-        },
-        {
-          provide: AUTHORIZATION_REDIRECT_URL,
-          useValue: redirectUrl,
-        },
-      ],
+      const routerStub = {
+        parseUrl: jest.fn(),
+      };
+
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          providers: [
+            {
+              provide: SecurityService,
+              useValue: securityStub,
+            },
+            {
+              provide: Router,
+              useValue: routerStub,
+            },
+            {
+              provide: AUTHORIZATION_REDIRECT_URL,
+              useValue: redirectUrl,
+            },
+          ],
+        });
+        guard = TestBed.inject(AuthorizedGuard);
+      });
+
+      it('should be created', () => {
+        expect(guard).toBeTruthy();
+      });
+
+      it('should allow activation when user is signed in', () => {
+        securityStub.isSignedIn.mockImplementationOnce(() => true);
+        const actual = guard.canActivate();
+        expect(actual).toBe(true);
+      });
+
+      it('should redirect when user is not signed in', () => {
+        const expectedUrlTree: UrlTree = {
+          fragment: redirectUrl,
+        } as UrlTree;
+
+        securityStub.isSignedIn.mockImplementationOnce(() => false);
+        routerStub.parseUrl.mockImplementationOnce(() => expectedUrlTree);
+
+        const actual = guard.canActivate();
+        expect(actual).toBe(expectedUrlTree);
+      });
     });
-    guard = TestBed.inject(AuthorizedGuard);
-  });
 
-  it('should be created', () => {
-    expect(guard).toBeTruthy();
-  });
-
-  it('should allow activation when user is signed in', () => {
-    securityStub.isSignedIn.mockImplementationOnce(() => true);
-    const actual = guard.canActivate();
-    expect(actual).toBe(true);
-  });
-
-  it('should redirect when user is not signed in', () => {
-    const expectedUrlTree: UrlTree = {
-      fragment: redirectUrl,
-    } as UrlTree;
-
-    securityStub.isSignedIn.mockImplementationOnce(() => false);
-    routerStub.parseUrl.mockImplementationOnce(() => expectedUrlTree);
-
-    const actual = guard.canActivate();
-    expect(actual).toBe(expectedUrlTree);
-  });
-});

--- a/src/app/security/guards/authorized.guard.ts
+++ b/src/app/security/guards/authorized.guard.ts
@@ -36,7 +36,6 @@ export class AuthorizedGuard implements CanActivate {
     if (this.security.isSignedIn()) {
       return true;
     }
-
     return this.redirect(this.redirectUrl);
   }
 

--- a/src/app/security/guards/authorized.guard.ts
+++ b/src/app/security/guards/authorized.guard.ts
@@ -27,20 +27,32 @@ import { AUTHORIZATION_REDIRECT_URL } from '../security.types';
 })
 export class AuthorizedGuard implements CanActivate {
   constructor(
-    private security: SecurityService,
-    private router: Router,
-    @Inject(AUTHORIZATION_REDIRECT_URL) private redirectUrl: string
+    protected security: SecurityService,
+    protected router: Router,
+    @Inject(AUTHORIZATION_REDIRECT_URL) protected redirectUrl: string
   ) {}
 
-  canActivate():
-    | Observable<boolean | UrlTree>
-    | Promise<boolean | UrlTree>
-    | boolean
-    | UrlTree {
+  canActivate(): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
     if (this.security.isSignedIn()) {
       return true;
     }
 
-    return this.router.parseUrl(this.redirectUrl);
+    return this.redirect(this.redirectUrl);
+  }
+
+  redirect(path: string): UrlTree {
+    return this.router.parseUrl(path);
+  }
+
+  protected getRouter(): Router {
+    return this.router;
+  }
+
+  protected getAuthorizationRedirectUrl(): string {
+    return this.redirectUrl;
+  }
+
+  protected getSecurityService(): SecurityService {
+    return this.security;
   }
 }

--- a/src/app/security/security.service.ts
+++ b/src/app/security/security.service.ts
@@ -184,6 +184,10 @@ export class SecurityService {
     return this.userDetails.hasSdeResearchUser();
   }
 
+  isOrganisationMember(): boolean {
+    return this.userDetails.sdeGetUserOrganisationMembership();
+  }
+
   /**
    * Gets the details of the current signed in user, or will get null if no user is signed in.
    *

--- a/src/app/security/security.service.ts
+++ b/src/app/security/security.service.ts
@@ -51,7 +51,7 @@ import {
 } from './security.types';
 import { UserDetails, UserDetailsService } from './user-details.service';
 import { ResearchPluginService } from '../mauro/research-plugin.service';
-import { SdeUserService } from '@maurodatamapper/sde-resources';
+import { SdeUserDetails, SdeUserService } from '@maurodatamapper/sde-resources';
 
 /**
  * Manages security operations on Mauro user interfaces.
@@ -182,6 +182,10 @@ export class SecurityService {
 
   isSignedInToSde(): boolean {
     return this.userDetails.hasSdeResearchUser();
+  }
+
+  getSignedinSdeUser(): SdeUserDetails | null {
+    return this.userDetails.getSdeResearchUser();
   }
 
   isOrganisationMember(): boolean {

--- a/src/app/security/user-details.service.ts
+++ b/src/app/security/user-details.service.ts
@@ -84,7 +84,6 @@ export class UserDetailsService {
     localStorage.setItem('needsToResetPassword', (user.needsToResetPassword ?? false).toString());
     localStorage.setItem('dataSpecificationFolder', JSON.stringify(user.dataSpecificationFolder));
     localStorage.setItem('sdeAuthToken', user.sdeAuthToken ?? '');
-    localStorage.setItem('organisationMembership', false.toString());
   }
 
   /**
@@ -100,6 +99,7 @@ export class UserDetailsService {
     localStorage.removeItem('needsToResetPassword');
     localStorage.removeItem('dataSpecificationFolder');
     localStorage.removeItem('sdeAuthToken');
+    localStorage.removeItem('sdeOrganisationMembership');
   }
 
   getSdeResearchUser(): SdeUserDetails | null {
@@ -127,7 +127,8 @@ export class UserDetailsService {
   }
 
   sdeGetUserOrganisationMembership(): boolean {
-    return localStorage.getItem('sdeOrganisationMembership') === 'true';
+    const membership = localStorage.getItem('sdeOrganisationMembership');
+    return membership === 'true';
   }
 
   hasSdeResearchUser(): boolean {
@@ -138,6 +139,6 @@ export class UserDetailsService {
     localStorage.removeItem('sdeUserId');
     localStorage.removeItem('sdeEmail');
     localStorage.removeItem('sdePreferredName');
-    localStorage.removeItem('organisationMembership');
+    localStorage.removeItem('sdeOrganisationMembership');
   }
 }

--- a/src/app/security/user-details.service.ts
+++ b/src/app/security/user-details.service.ts
@@ -44,7 +44,7 @@ export interface UserDetails {
   providedIn: 'root',
 })
 export class UserDetailsService {
-  constructor() { }
+  constructor() {}
 
   /**
    * Gets the current user in use, or null if there is no current user.
@@ -81,15 +81,10 @@ export class UserDetailsService {
     localStorage.setItem('lastName', user.lastName);
     localStorage.setItem('email', user.email);
     localStorage.setItem('role', user.role ?? '');
-    localStorage.setItem(
-      'needsToResetPassword',
-      (user.needsToResetPassword ?? false).toString()
-    );
-    localStorage.setItem(
-      'dataSpecificationFolder',
-      JSON.stringify(user.dataSpecificationFolder)
-    );
+    localStorage.setItem('needsToResetPassword', (user.needsToResetPassword ?? false).toString());
+    localStorage.setItem('dataSpecificationFolder', JSON.stringify(user.dataSpecificationFolder));
     localStorage.setItem('sdeAuthToken', user.sdeAuthToken ?? '');
+    localStorage.setItem('organisationMembership', false.toString());
   }
 
   /**
@@ -127,6 +122,14 @@ export class UserDetailsService {
     localStorage.setItem('sdePreferredName', user.preferredName ?? '');
   }
 
+  sdeSetUserOrganisationMembership(status: boolean) {
+    localStorage.setItem('sdeOrganisationMembership', status.toString());
+  }
+
+  sdeGetUserOrganisationMembership(): boolean {
+    return localStorage.getItem('sdeOrganisationMembership') === 'true';
+  }
+
   hasSdeResearchUser(): boolean {
     return !!localStorage.getItem('sdeUserId');
   }
@@ -135,5 +138,6 @@ export class UserDetailsService {
     localStorage.removeItem('sdeUserId');
     localStorage.removeItem('sdeEmail');
     localStorage.removeItem('sdePreferredName');
+    localStorage.removeItem('organisationMembership');
   }
 }

--- a/src/app/shared/guards/organisation-member.guard.spec.ts
+++ b/src/app/shared/guards/organisation-member.guard.spec.ts
@@ -1,0 +1,157 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, UrlTree } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { OrganisationMemberGuard } from './organisation-member.guard';
+import { SecurityService } from '../../security/security.service';
+import { SdeUserService } from '@maurodatamapper/sde-resources';
+import { UserDetailsService } from 'src/app/security/user-details.service';
+import { AUTHORIZATION_REDIRECT_URL } from '../../security/security.types';
+
+describe('OrganisationMemberGuard', () => {
+  let guard: OrganisationMemberGuard;
+  let securityService: jest.Mocked<SecurityService>;
+  let router: jest.Mocked<Router>;
+  let userService: jest.Mocked<SdeUserService>;
+  let detailsService: jest.Mocked<UserDetailsService>;
+
+  const redirectUrl = 'some/where/else';
+
+  beforeEach(() => {
+    const securityMock = {
+      isSignedInToSde: jest.fn(),
+      isOrganisationMember: jest.fn(),
+      getSignedinSdeUser: jest.fn(),
+    } as unknown as jest.Mocked<SecurityService>;
+
+    const routerMock = {
+      parseUrl: jest.fn(),
+    } as unknown as jest.Mocked<Router>;
+
+    const userMock = {
+      isSdeUserAMemberOfAnOrganisation: jest.fn(),
+    } as unknown as jest.Mocked<SdeUserService>;
+
+    const detailsMock = {
+      sdeSetUserOrganisationMembership: jest.fn(),
+    } as unknown as jest.Mocked<UserDetailsService>;
+
+    TestBed.configureTestingModule({
+      providers: [
+        OrganisationMemberGuard,
+        { provide: SecurityService, useValue: securityMock },
+        { provide: Router, useValue: routerMock },
+        { provide: SdeUserService, useValue: userMock },
+        { provide: UserDetailsService, useValue: detailsMock },
+        { provide: AUTHORIZATION_REDIRECT_URL, useValue: redirectUrl },
+      ],
+    });
+
+    guard = TestBed.inject(OrganisationMemberGuard);
+    securityService = TestBed.inject(SecurityService) as jest.Mocked<SecurityService>;
+    router = TestBed.inject(Router) as jest.Mocked<Router>;
+    userService = TestBed.inject(SdeUserService) as jest.Mocked<SdeUserService>;
+    detailsService = TestBed.inject(UserDetailsService) as jest.Mocked<UserDetailsService>;
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+
+  it('should redirect if user is not signed in to SDE', (done) => {
+    securityService.isSignedInToSde.mockReturnValue(false);
+    router.parseUrl.mockReturnValue({} as UrlTree);
+
+    const result = guard.canActivate();
+
+    if (result instanceof Observable) {
+      result.subscribe((res) => {
+        expect(res).toEqual(router.parseUrl(redirectUrl));
+        done();
+      });
+    } else {
+      expect(result).toEqual(router.parseUrl(redirectUrl));
+      done();
+    }
+  });
+
+  it('should allow activation if user is an organisation member', () => {
+    securityService.isSignedInToSde.mockReturnValue(true);
+    securityService.isOrganisationMember.mockReturnValue(true);
+
+    const result = guard.canActivate();
+
+    expect(result).toBe(true);
+  });
+
+  it('should check organisation membership if user is signed in but not an organisation member', () => {
+    securityService.isSignedInToSde.mockReturnValue(true);
+    securityService.isOrganisationMember.mockReturnValue(false);
+    securityService.getSignedinSdeUser.mockReturnValue({
+      id: 'user-id',
+      firstName: '',
+      lastName: '',
+      email: '',
+    });
+    userService.isSdeUserAMemberOfAnOrganisation.mockReturnValue(of(true));
+    detailsService.sdeSetUserOrganisationMembership.mockImplementation(() => {});
+
+    const result = guard.canActivate();
+
+    if (result instanceof Observable) {
+      result.subscribe((res) => {
+        expect(res).toBe(true);
+        expect(() => detailsService.sdeSetUserOrganisationMembership(true)).not.toThrow();
+      });
+    } else if (result instanceof Promise) {
+      result.then((res) => {
+        expect(res).toBe(true);
+        expect(() => detailsService.sdeSetUserOrganisationMembership(true)).not.toThrow();
+      });
+    } else {
+      expect(result).toBe(true);
+      expect(() => detailsService.sdeSetUserOrganisationMembership(true)).not.toThrow();
+    }
+  });
+
+  it('should redirect if user is not an organisation member and membership check fails', () => {
+    securityService.isSignedInToSde.mockReturnValue(true);
+    securityService.isOrganisationMember.mockReturnValue(false);
+    securityService.getSignedinSdeUser.mockReturnValue({
+      id: 'user-id',
+      firstName: '',
+      lastName: '',
+      email: '',
+    });
+    userService.isSdeUserAMemberOfAnOrganisation.mockReturnValue(of(false));
+    router.parseUrl.mockReturnValue({} as UrlTree);
+
+    const result = guard.canActivate() as ReturnType<typeof guard.canActivate>;
+
+    if (result instanceof Observable) {
+      result.subscribe((res) => {
+        expect(res).toEqual(router.parseUrl('/sde'));
+      });
+    } else {
+      expect(result).toEqual(router.parseUrl('/sde'));
+    }
+  });
+
+  it('should redirect if no signed-in SDE user is found', (done) => {
+    securityService.isSignedInToSde.mockReturnValue(true);
+    securityService.isOrganisationMember.mockReturnValue(false);
+    securityService.getSignedinSdeUser.mockReturnValue(null);
+    router.parseUrl.mockReturnValue({} as UrlTree);
+
+    const result = guard.canActivate();
+
+    if (result instanceof Observable) {
+      result.subscribe((res) => {
+        expect(res).toEqual(router.parseUrl('/sde'));
+        done();
+      });
+    } else {
+      expect(result).toEqual(router.parseUrl('/sde'));
+      done();
+    }
+  });
+});

--- a/src/app/shared/guards/organisation-member.guard.spec.ts
+++ b/src/app/shared/guards/organisation-member.guard.spec.ts
@@ -1,3 +1,21 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
 import { TestBed } from '@angular/core/testing';
 import { Router, UrlTree } from '@angular/router';
 import { Observable, of } from 'rxjs';

--- a/src/app/shared/guards/organisation-member.guard.ts
+++ b/src/app/shared/guards/organisation-member.guard.ts
@@ -20,7 +20,7 @@ import { Inject, Injectable } from '@angular/core';
 import { Router, UrlTree } from '@angular/router';
 import { map, Observable } from 'rxjs';
 import { AuthorizedGuard } from '../../security/guards/authorized.guard';
-import { UserService } from '@maurodatamapper/sde-resources';
+import { SdeUserService } from '@maurodatamapper/sde-resources';
 import { AUTHORIZATION_REDIRECT_URL } from '../../security/security.types';
 import { SecurityService } from '../../security/security.service';
 import { UserDetailsService } from 'src/app/security/user-details.service';
@@ -32,7 +32,7 @@ export class OrganisationMemberGuard extends AuthorizedGuard {
   constructor(
     protected override security: SecurityService,
     protected override router: Router,
-    protected userService: UserService,
+    protected userService: SdeUserService,
     protected detailsService: UserDetailsService,
     @Inject(AUTHORIZATION_REDIRECT_URL) protected override redirectUrl: string
   ) {
@@ -43,23 +43,28 @@ export class OrganisationMemberGuard extends AuthorizedGuard {
     | Promise<boolean | UrlTree>
     | boolean
     | UrlTree {
-    if (!this.getSecurityService().isSignedIn) {
+    if (!this.getSecurityService().isSignedInToSde) {
       return this.redirect(this.getAuthorizationRedirectUrl());
     }
 
     if (this.getSecurityService().isOrganisationMember()) {
       return true;
     } else {
-      return this.userService.isCurrentUserAMemberOfAnOrganisation().pipe(
-        map((bool: boolean) => {
-          if (bool) {
-            this.detailsService.sdeSetUserOrganisationMembership(bool);
-            return true;
-          }
-          // redirect to requests page
-          return this.redirect('/sde');
-        })
-      );
+      const sdeUser = this.getSecurityService().getSignedinSdeUser();
+      if (sdeUser) {
+        return this.userService.isSdeUserAMemberOfAnOrganisation(sdeUser.id).pipe(
+          map((bool: boolean) => {
+            if (bool) {
+              this.detailsService.sdeSetUserOrganisationMembership(bool);
+              return true;
+            }
+            // redirect to requests page
+            return this.redirect('/sde');
+          })
+        );
+      } else {
+        return this.redirect('/sde');
+      }
     }
   }
 }

--- a/src/app/shared/guards/organisation-member.guard.ts
+++ b/src/app/shared/guards/organisation-member.guard.ts
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { Inject, Injectable } from '@angular/core';
 import { Router, UrlTree } from '@angular/router';
-import { map, Observable } from 'rxjs';
+import { map, Observable, of, switchMap } from 'rxjs';
 import { AuthorizedGuard } from '../../security/guards/authorized.guard';
 import { SdeUserService } from '@maurodatamapper/sde-resources';
 import { AUTHORIZATION_REDIRECT_URL } from '../../security/security.types';
@@ -53,17 +53,17 @@ export class OrganisationMemberGuard extends AuthorizedGuard {
       const sdeUser = this.getSecurityService().getSignedinSdeUser();
       if (sdeUser) {
         return this.userService.isSdeUserAMemberOfAnOrganisation(sdeUser.id).pipe(
-          map((bool: boolean) => {
+          switchMap((bool: boolean) => {
             if (bool) {
               this.detailsService.sdeSetUserOrganisationMembership(bool);
-              return true;
+              return of(true);
             }
             // redirect to requests page
-            return this.redirect('/sde');
+            return of(this.redirect('/sde'));
           })
         );
       } else {
-        return this.redirect('/sde');
+        return of(this.redirect(this.getAuthorizationRedirectUrl()));
       }
     }
   }

--- a/src/app/shared/guards/organisation-member.guard.ts
+++ b/src/app/shared/guards/organisation-member.guard.ts
@@ -1,0 +1,65 @@
+/*
+Copyright 2022-2023 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Inject, Injectable } from '@angular/core';
+import { Router, UrlTree } from '@angular/router';
+import { map, Observable } from 'rxjs';
+import { AuthorizedGuard } from '../../security/guards/authorized.guard';
+import { UserService } from '@maurodatamapper/sde-resources';
+import { AUTHORIZATION_REDIRECT_URL } from '../../security/security.types';
+import { SecurityService } from '../../security/security.service';
+import { UserDetailsService } from 'src/app/security/user-details.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OrganisationMemberGuard extends AuthorizedGuard {
+  constructor(
+    protected override security: SecurityService,
+    protected override router: Router,
+    protected userService: UserService,
+    protected detailsService: UserDetailsService,
+    @Inject(AUTHORIZATION_REDIRECT_URL) protected override redirectUrl: string
+  ) {
+    super(security, router, redirectUrl);
+  }
+  override canActivate():
+    | Observable<boolean | UrlTree>
+    | Promise<boolean | UrlTree>
+    | boolean
+    | UrlTree {
+    if (!this.getSecurityService().isSignedIn) {
+      return this.redirect(this.getAuthorizationRedirectUrl());
+    }
+
+    if (this.getSecurityService().isOrganisationMember()) {
+      return true;
+    } else {
+      return this.userService.isCurrentUserAMemberOfAnOrganisation().pipe(
+        map((bool: boolean) => {
+          if (bool) {
+            this.detailsService.sdeSetUserOrganisationMembership(bool);
+            return true;
+          }
+          // redirect to requests page
+          return this.redirect('/sde');
+        })
+      );
+    }
+  }
+}

--- a/src/app/shared/header/header.component.html
+++ b/src/app/shared/header/header.component.html
@@ -39,7 +39,7 @@ SPDX-License-Identifier: Apache-2.0
     <nav class="mdm-header__links--main" role="navigation" aria-label="Site navigation">
       <ul>
         <li *ngFor="let link of links">
-            <a [ngClass]="{'invisible': (( link.onlySignedIn ||link.onlySignedIn && !isSignedIn) || (link.onlyOrganisationMember && !isOrganisationMember))}"
+            <a [ngClass]="{'invisible': ((link.onlySignedIn && !isSignedIn) || (link.onlyOrganisationMember && !isOrganisationMember))}"
             [routerLink]="link.routerLink"
             routerLinkActive="active"
           >
@@ -83,7 +83,7 @@ SPDX-License-Identifier: Apache-2.0
         <li>
           <a
             [id]="accountLink.routerLink"
-            [ngClass]="{'invisible': (( accountLink.onlySignedIn ||accountLink.onlySignedIn && !isSignedIn) || (accountLink.onlyOrganisationMember && !isOrganisationMember))}"
+            [ngClass]="{'invisible': ((accountLink.onlySignedIn && !isSignedIn) || (accountLink.onlyOrganisationMember && !isOrganisationMember))}"
             [routerLink]="accountLink.routerLink"
             routerLinkActive="active"
           >

--- a/src/app/shared/header/header.component.html
+++ b/src/app/shared/header/header.component.html
@@ -39,8 +39,7 @@ SPDX-License-Identifier: Apache-2.0
     <nav class="mdm-header__links--main" role="navigation" aria-label="Site navigation">
       <ul>
         <li *ngFor="let link of links">
-          <a
-            *ngIf="!link.onlySignedIn || (link.onlySignedIn && isSignedIn)"
+            <a [ngClass]="{'invisible': (( link.onlySignedIn ||link.onlySignedIn && !isSignedIn) || (link.onlyOrganisationMember && !isOrganisationMember))}"
             [routerLink]="link.routerLink"
             routerLinkActive="active"
           >
@@ -73,7 +72,7 @@ SPDX-License-Identifier: Apache-2.0
         <li *ngFor="let rightLink of rightLinks">
           <a
             [id]="rightLink.routerLink"
-            *ngIf="!rightLink.onlySignedIn || (rightLink.onlySignedIn && isSignedIn)"
+           [ngClass]="{'invisible': (( rightLink.onlySignedIn ||rightLink.onlySignedIn && !isSignedIn) || (rightLink.onlyOrganisationMember && !isOrganisationMember))}"
             [routerLink]="rightLink.routerLink"
             routerLinkActive="active"
           >
@@ -84,7 +83,7 @@ SPDX-License-Identifier: Apache-2.0
         <li>
           <a
             [id]="accountLink.routerLink"
-            *ngIf="!accountLink.onlySignedIn || (accountLink.onlySignedIn && isSignedIn)"
+            [ngClass]="{'invisible': (( accountLink.onlySignedIn ||accountLink.onlySignedIn && !isSignedIn) || (accountLink.onlyOrganisationMember && !isOrganisationMember))}"
             [routerLink]="accountLink.routerLink"
             routerLinkActive="active"
           >

--- a/src/app/shared/header/header.component.scss
+++ b/src/app/shared/header/header.component.scss
@@ -27,6 +27,10 @@ $header-text: $color-primary-contrast;
 $data-specification-count-color: $color-dataSpecificationCount;
 $link-color: $header-text;
 
+.invisible {
+  display: none !important;
+}
+
 .mdm-header {
   position: relative;
   z-index: 2;
@@ -228,3 +232,4 @@ $link-color: $header-text;
   color: $color-applicationTypeBanner-text;
   font-weight: 500;
 }
+

--- a/src/app/shared/header/header.component.ts
+++ b/src/app/shared/header/header.component.ts
@@ -44,6 +44,8 @@ export interface HeaderLink {
    */
   onlySignedIn?: boolean;
 
+  onlyOrganisationMember?: boolean;
+
   arrow?: ArrowDirection;
 
   /**
@@ -114,11 +116,21 @@ export class HeaderComponent {
    */
   @Input() signedInUser?: UserDetails | null;
 
+  /**
+   * if the signed in sde user has an Organisation Membership
+   * {@Link OrganisationMemberGuard}
+   */
+  @Input() organisationMember?: boolean | null;
+
   get includeSignIn() {
     return !!this.signInLink;
   }
 
   get isSignedIn() {
     return !!this.signedInUser;
+  }
+
+  get isOrganisationMember() {
+    return this.organisationMember ?? false;
   }
 }


### PR DESCRIPTION
Adds a route guard and adjusts controlls based on if the signed in user is a member of an organisation.
Clicking a link wile not being a member redirect s to the request page.

Supported by:

https://github.com/MauroDataMapper/sde-resources/pull/244

https://github.com/MauroDataMapper/sde-core/pull/343

closes #450 