### PR TITLE
gh-512: Reorganise tabs and menus

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.formatOnSave": true,
   "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "vscode.typescript-language-features"
   },
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
@@ -10,7 +10,7 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[html]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "vscode.html-language-features"
   },
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.formatOnSave": true,
   "[typescript]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
@@ -10,7 +10,7 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[html]": {
-    "editor.defaultFormatter": "vscode.html-language-features"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -96,11 +96,7 @@ export class AppComponent implements OnInit, OnDestroy {
     },
   ];
 
-  headerLinks: HeaderLink[] = [
-    {
-      label: 'About',
-      routerLink: '/about',
-    },
+  catalogueMenuLinks: HeaderLink[] = [
     {
       label: 'Browse',
       routerLink: '/browse',
@@ -110,6 +106,29 @@ export class AppComponent implements OnInit, OnDestroy {
       label: 'Search',
       routerLink: '/search',
       onlyOrganisationMember: true,
+    }
+  ];
+
+  headerLinks: HeaderLink[] = [
+    {
+      label: 'Home',
+      routerLink: '/home',
+    },
+    {
+      label: 'Organisations',
+      routerLink: '/organisations',
+    },
+    {
+      label: 'Projects',
+      routerLink: '/projects',
+      onlySignedIn: true,
+    },
+    {
+      label: 'Catalogue',
+      routerLink: '',
+      arrow: 'angle-down',
+      menuLinks: this.catalogueMenuLinks,
+      onlySignedIn: true
     },
     /* Temporarily removed
     {
@@ -121,6 +140,10 @@ export class AppComponent implements OnInit, OnDestroy {
       label: 'Requests',
       routerLink: '/sde',
       onlySignedIn: true,
+    },
+    {
+      label: 'About',
+      routerLink: '/about',
     },
     {
       label: 'Help',
@@ -236,7 +259,7 @@ export class AppComponent implements OnInit, OnDestroy {
             (this.draftDataSpecificationsCount = draftDataSpecificationsCount)
         )
       )
-      .subscribe(() => {});
+      .subscribe(() => { });
 
     this.broadcast
       .on('sign-out-user')
@@ -363,7 +386,7 @@ export class AppComponent implements OnInit, OnDestroy {
             (this.draftDataSpecificationsCount = draftDataSpecificationsCount)
         )
       )
-      .subscribe(() => {});
+      .subscribe(() => { });
 
     this.broadcast
       .on('data-specification-finalised')
@@ -375,7 +398,7 @@ export class AppComponent implements OnInit, OnDestroy {
             (this.draftDataSpecificationsCount = draftDataSpecificationsCount)
         )
       )
-      .subscribe(() => {});
+      .subscribe(() => { });
   }
 
   private setupIdleTimer() {
@@ -383,7 +406,7 @@ export class AppComponent implements OnInit, OnDestroy {
     this.userIdle
       .onTimerStart()
       .pipe(takeUntil(this.unsubscribe$))
-      .subscribe(() => {});
+      .subscribe(() => { });
 
     let lastCheck = new Date();
     this.userIdle

--- a/src/app/pages/organisations/organisations.component.html
+++ b/src/app/pages/organisations/organisations.component.html
@@ -16,11 +16,10 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<div class="container sde-main">
-  <div class="main-row hero">
-    <h1>Requests</h1>
-    <mdm-sde-sign-in *ngIf="!signedIn"></mdm-sde-sign-in>
-    <mdm-sde-requests></mdm-sde-requests>
-        <sde-project-page [isReadOnly]="true"></sde-project-page>
-  </div>
+<div class="container">
+    <div class="main-row hero">
+        <h1>Organisations</h1>
+        <mdm-sde-sign-in *ngIf="!signedIn"></mdm-sde-sign-in>
+        <mdm-departments></mdm-departments>
+    </div>
 </div>

--- a/src/app/pages/organisations/organisations.component.spec.ts
+++ b/src/app/pages/organisations/organisations.component.spec.ts
@@ -1,4 +1,4 @@
-<!--
+/*
 Copyright 2022-2023 University of Oxford
 and Health and Social Care Information Centre, also known as NHS Digital
 
@@ -15,12 +15,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
--->
-<div class="container sde-main">
-  <div class="main-row hero">
-    <h1>Requests</h1>
-    <mdm-sde-sign-in *ngIf="!signedIn"></mdm-sde-sign-in>
-    <mdm-sde-requests></mdm-sde-requests>
-        <sde-project-page [isReadOnly]="true"></sde-project-page>
-  </div>
-</div>
+*/
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OrganisationsComponent } from './organisations.component';
+
+describe('OrganisationsComponent', () => {
+  let component: OrganisationsComponent;
+  let fixture: ComponentFixture<OrganisationsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [OrganisationsComponent]
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(OrganisationsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/organisations/organisations.component.spec.ts
+++ b/src/app/pages/organisations/organisations.component.spec.ts
@@ -16,26 +16,38 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SecurityService } from 'src/app/security/security.service';
+import { createSecurityServiceStub } from 'src/app/testing/stubs/security.stub';
+import { MembershipEndpointsResearcher } from '@maurodatamapper/sde-resources';
+import {
+  ComponentHarness,
+  setupTestModuleForComponent,
+} from 'src/app/testing/testing.helpers';
 
 import { OrganisationsComponent } from './organisations.component';
+import { createMembershipEndpointsResearcherStub } from 'src/app/testing/stubs/sde/memberships-endpoints-researcher.stub';
 
-describe('OrganisationsComponent', () => {
-  let component: OrganisationsComponent;
-  let fixture: ComponentFixture<OrganisationsComponent>;
+describe('ProjectsComponent', () => {
+  let harness: ComponentHarness<OrganisationsComponent>;
+  const securityStub = createSecurityServiceStub();
+  const membershipEndpointsResearcherStub = createMembershipEndpointsResearcherStub();
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [OrganisationsComponent]
-    })
-      .compileComponents();
-
-    fixture = TestBed.createComponent(OrganisationsComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    harness = await setupTestModuleForComponent(OrganisationsComponent, {
+      providers: [
+        {
+          provide: SecurityService,
+          useValue: securityStub,
+        },
+        {
+          provide: MembershipEndpointsResearcher,
+          useValue: membershipEndpointsResearcherStub,
+        },
+      ],
+    });
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(harness.isComponentCreated).toBeTruthy();
   });
 });

--- a/src/app/pages/organisations/organisations.component.ts
+++ b/src/app/pages/organisations/organisations.component.ts
@@ -16,27 +16,21 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
-import { MatTabChangeEvent, MatTabGroup } from '@angular/material/tabs';
-import { MembershipEndpointsResearcher, RequestFilterMode } from '@maurodatamapper/sde-resources';
+import { Component, OnInit } from '@angular/core';
+import { MembershipEndpointsResearcher } from '@maurodatamapper/sde-resources';
 import { SecurityService } from 'src/app/security/security.service';
 
 @Component({
-  templateUrl: './sde-main.component.html',
-  styleUrls: ['./sde-main.component.scss'],
+  templateUrl: './organisations.component.html'
 })
-export class SdeMainComponent implements OnInit, AfterViewInit {
+export class OrganisationsComponent implements OnInit {
   signedIn = false;
   restrictAccess = true;
-  requestsNeedingApprovalListConfig: RequestFilterMode = RequestFilterMode.CanAuthorise;
-  currentTabIndex = 1;
 
   constructor(
     private security: SecurityService,
     private membershipEndpointsResearcher: MembershipEndpointsResearcher
   ) { }
-
-  ngAfterViewInit(): void {}
 
   ngOnInit(): void {
     this.signedIn = this.security.isSignedInToSde();
@@ -45,13 +39,5 @@ export class SdeMainComponent implements OnInit, AfterViewInit {
         this.restrictAccess = organisation === null;
       });
     }
-  }
-
-  getSelectedIndex(): number {
-    return this.currentTabIndex;
-  }
-
-  onTabChange(event: MatTabChangeEvent) {
-    this.currentTabIndex = event.index;
   }
 }

--- a/src/app/pages/pages.module.ts
+++ b/src/app/pages/pages.module.ts
@@ -51,6 +51,8 @@ import { SdeMainComponent } from './sde-main/sde-main.component';
 import { SecureDataEnvironmentModule } from '../secure-data-environment/secure-data-environment.module';
 import { SdeAuthenticationFinalizeComponent } from './sde-authentication-finalize/sde-authentication-finalize.component';
 import { UserRegistrationComponent } from './user-registration/user-registration.component';
+import { OrganisationsComponent } from './organisations/organisations.component';
+import { ProjectsComponent } from './projects/projects.component';
 
 @NgModule({
   declarations: [
@@ -81,6 +83,8 @@ import { UserRegistrationComponent } from './user-registration/user-registration
     TemplateDataSpecificationDetailComponent,
     SdeMainComponent,
     SdeAuthenticationFinalizeComponent,
+    OrganisationsComponent,
+    ProjectsComponent,
   ],
   imports: [
     CoreModule,

--- a/src/app/pages/pages.routes.ts
+++ b/src/app/pages/pages.routes.ts
@@ -46,6 +46,7 @@ import { SdeAuthenticationFinalizeComponent } from './sde-authentication-finaliz
 import { UserRegistrationComponent } from './user-registration/user-registration.component';
 import { OrganisationMemberGuard } from '../shared/guards/organisation-member.guard';
 import { ProjectsComponent } from './projects/projects.component';
+import { OrganisationsComponent } from './organisations/organisations.component';
 
 export const buildStaticContentRoute = (path: string, staticAssetPath: string): Route => {
   return {

--- a/src/app/pages/pages.routes.ts
+++ b/src/app/pages/pages.routes.ts
@@ -45,6 +45,7 @@ import { SdeMainComponent } from './sde-main/sde-main.component';
 import { SdeAuthenticationFinalizeComponent } from './sde-authentication-finalize/sde-authentication-finalize.component';
 import { UserRegistrationComponent } from './user-registration/user-registration.component';
 import { OrganisationMemberGuard } from '../shared/guards/organisation-member.guard';
+import { ProjectsComponent } from './projects/projects.component';
 
 export const buildStaticContentRoute = (path: string, staticAssetPath: string): Route => {
   return {
@@ -199,4 +200,14 @@ export const routes: Route[] = [
     path: 'sde/auth/finalize/:action',
     component: SdeAuthenticationFinalizeComponent,
   },
+  {
+    path: 'organisations',
+    component: OrganisationsComponent,
+    canActivate: [AuthorizedGuard],
+  },
+  {
+    path: 'projects',
+    component: ProjectsComponent,
+    canActivate: [AuthorizedGuard],
+  }
 ];

--- a/src/app/pages/projects/projects.component.html
+++ b/src/app/pages/projects/projects.component.html
@@ -19,15 +19,6 @@ SPDX-License-Identifier: Apache-2.0
 <div class="container">
     <div class="main-row hero">
         <h1>Projects</h1>
-        <mdm-sde-sign-in *ngIf="!signedIn"></mdm-sde-sign-in>
-        <div class="medium-top-spacer flex-container__card">
-            <sde-requests-list [useConfig]="requestsNeedingApprovalListConfig"></sde-requests-list>
-            <div class="help-text mt-2">
-                <i class="bi bi-info-circle-fill info-icon"></i>
-                <span>
-                    A list of all project scoped requests that require approval at this project.
-                </span>
-            </div>
-        </div>
+        <sde-project-page [isReadOnly]="true"></sde-project-page>
     </div>
 </div>

--- a/src/app/pages/projects/projects.component.html
+++ b/src/app/pages/projects/projects.component.html
@@ -16,11 +16,18 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<div class="container sde-main">
-  <div class="main-row hero">
-    <h1>Requests</h1>
-    <mdm-sde-sign-in *ngIf="!signedIn"></mdm-sde-sign-in>
-    <mdm-sde-requests></mdm-sde-requests>
-        <sde-project-page [isReadOnly]="true"></sde-project-page>
-  </div>
+<div class="container">
+    <div class="main-row hero">
+        <h1>Projects</h1>
+        <mdm-sde-sign-in *ngIf="!signedIn"></mdm-sde-sign-in>
+        <div class="medium-top-spacer flex-container__card">
+            <sde-requests-list [useConfig]="requestsNeedingApprovalListConfig"></sde-requests-list>
+            <div class="help-text mt-2">
+                <i class="bi bi-info-circle-fill info-icon"></i>
+                <span>
+                    A list of all project scoped requests that require approval at this project.
+                </span>
+            </div>
+        </div>
+    </div>
 </div>

--- a/src/app/pages/projects/projects.component.spec.ts
+++ b/src/app/pages/projects/projects.component.spec.ts
@@ -16,26 +16,38 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SecurityService } from 'src/app/security/security.service';
+import { createSecurityServiceStub } from 'src/app/testing/stubs/security.stub';
+import { MembershipEndpointsResearcher } from '@maurodatamapper/sde-resources';
+import {
+  ComponentHarness,
+  setupTestModuleForComponent,
+} from 'src/app/testing/testing.helpers';
 
 import { ProjectsComponent } from './projects.component';
+import { createMembershipEndpointsResearcherStub } from 'src/app/testing/stubs/sde/memberships-endpoints-researcher.stub';
 
 describe('ProjectsComponent', () => {
-  let component: ProjectsComponent;
-  let fixture: ComponentFixture<ProjectsComponent>;
+  let harness: ComponentHarness<ProjectsComponent>;
+  const securityStub = createSecurityServiceStub();
+  const membershipEndpointsResearcherStub = createMembershipEndpointsResearcherStub();
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ProjectsComponent]
-    })
-      .compileComponents();
-
-    fixture = TestBed.createComponent(ProjectsComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    harness = await setupTestModuleForComponent(ProjectsComponent, {
+      providers: [
+        {
+          provide: SecurityService,
+          useValue: securityStub,
+        },
+        {
+          provide: MembershipEndpointsResearcher,
+          useValue: membershipEndpointsResearcherStub,
+        },
+      ],
+    });
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(harness.isComponentCreated).toBeTruthy();
   });
 });

--- a/src/app/pages/projects/projects.component.spec.ts
+++ b/src/app/pages/projects/projects.component.spec.ts
@@ -1,4 +1,4 @@
-<!--
+/*
 Copyright 2022-2023 University of Oxford
 and Health and Social Care Information Centre, also known as NHS Digital
 
@@ -15,12 +15,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
--->
-<div class="container sde-main">
-  <div class="main-row hero">
-    <h1>Requests</h1>
-    <mdm-sde-sign-in *ngIf="!signedIn"></mdm-sde-sign-in>
-    <mdm-sde-requests></mdm-sde-requests>
-        <sde-project-page [isReadOnly]="true"></sde-project-page>
-  </div>
-</div>
+*/
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProjectsComponent } from './projects.component';
+
+describe('ProjectsComponent', () => {
+  let component: ProjectsComponent;
+  let fixture: ComponentFixture<ProjectsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ProjectsComponent]
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(ProjectsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/projects/projects.component.ts
+++ b/src/app/pages/projects/projects.component.ts
@@ -16,27 +16,22 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
-import { MatTabChangeEvent, MatTabGroup } from '@angular/material/tabs';
+import { Component, OnInit } from '@angular/core';
 import { MembershipEndpointsResearcher, RequestFilterMode } from '@maurodatamapper/sde-resources';
 import { SecurityService } from 'src/app/security/security.service';
 
 @Component({
-  templateUrl: './sde-main.component.html',
-  styleUrls: ['./sde-main.component.scss'],
+  templateUrl: './projects.component.html'
 })
-export class SdeMainComponent implements OnInit, AfterViewInit {
+export class ProjectsComponent implements OnInit {
   signedIn = false;
   restrictAccess = true;
   requestsNeedingApprovalListConfig: RequestFilterMode = RequestFilterMode.CanAuthorise;
-  currentTabIndex = 1;
 
   constructor(
     private security: SecurityService,
     private membershipEndpointsResearcher: MembershipEndpointsResearcher
   ) { }
-
-  ngAfterViewInit(): void {}
 
   ngOnInit(): void {
     this.signedIn = this.security.isSignedInToSde();
@@ -45,13 +40,5 @@ export class SdeMainComponent implements OnInit, AfterViewInit {
         this.restrictAccess = organisation === null;
       });
     }
-  }
-
-  getSelectedIndex(): number {
-    return this.currentTabIndex;
-  }
-
-  onTabChange(event: MatTabChangeEvent) {
-    this.currentTabIndex = event.index;
   }
 }

--- a/src/app/pages/sde-main/sde-main.component.html
+++ b/src/app/pages/sde-main/sde-main.component.html
@@ -21,6 +21,5 @@ SPDX-License-Identifier: Apache-2.0
     <h1>Requests</h1>
     <mdm-sde-sign-in *ngIf="!signedIn"></mdm-sde-sign-in>
     <mdm-sde-requests></mdm-sde-requests>
-        <sde-project-page [isReadOnly]="true"></sde-project-page>
   </div>
 </div>

--- a/src/app/shared/header/header.component.html
+++ b/src/app/shared/header/header.component.html
@@ -27,10 +27,7 @@ SPDX-License-Identifier: Apache-2.0
   </div>
   <div class="mdm-header__logo--align-right">
     <a [routerLink]="logoLink?.routerLink ?? ''">
-      <img
-        [src]="logoLink?.customRightImageSrc || logoLink?.defaultRightImageSrc"
-        [alt]="logoLink?.label"
-      />
+      <img [src]="logoLink?.customRightImageSrc || logoLink?.defaultRightImageSrc" [alt]="logoLink?.label" />
     </a>
   </div>
 </header>
@@ -38,61 +35,45 @@ SPDX-License-Identifier: Apache-2.0
   <div class="mdm-header__links">
     <nav class="mdm-header__links--main" role="navigation" aria-label="Site navigation">
       <ul>
+        <!-- Include a menu if there are links -->
         <li *ngFor="let link of links">
             <a [ngClass]="{'invisible': ((link.onlySignedIn && !isSignedIn) || (link.onlyOrganisationMember && !isOrganisationMember))}"
-            [routerLink]="link.routerLink"
-            routerLinkActive="active"
-          >
-            <span
-              >{{ link.label }} <span [mdmArrow]="link.arrow" [matMenuTriggerFor]="menu"> </span
-            ></span>
-          </a>
-
-          <!-- Lazily rendered dropdown menu.  -->
-          <mat-menu #menu="matMenu" xPosition="after" yPosition="below">
-            <ng-template matMenuContent>
-              <a
-                *ngFor="let menuItem of link.menuLinks"
-                [routerLink]="menuItem.routerLink"
-                mat-menu-item
-                >{{ menuItem.label }}</a
-              >
-            </ng-template>
-          </mat-menu>
+              <span [matMenuTriggerFor]="menu" style="cursor: pointer">{{ link.label }} <span [mdmArrow]="link.arrow">
+                </span></span>
+            </a>
+            <!-- Lazily rendered dropdown menu.  -->
+            <mat-menu #menu="matMenu" xPosition="after" yPosition="below">
+              <ng-template matMenuContent>
+                <a *ngFor="let menuItem of link.menuLinks" [routerLink]="menuItem.routerLink" mat-menu-item>{{
+                  menuItem.label }}</a>
+              </ng-template>
+            </mat-menu>
+          </ng-container>
+          <ng-template #noLinks>
+            <a *ngIf="!link.onlySignedIn || (link.onlySignedIn && isSignedIn)" [routerLink]="link.routerLink"
+              routerLinkActive="active">
+              <span>{{ link.label }} <span [mdmArrow]="link.arrow"> </span></span>
+            </a>
+          </ng-template>
         </li>
       </ul>
     </nav>
-    <nav
-      *ngIf="isSignedIn"
-      class="mdm-header__links--right"
-      role="navigation"
-      aria-label="User navigation"
-    >
+    <nav *ngIf="isSignedIn" class="mdm-header__links--right" role="navigation" aria-label="User navigation">
       <ul>
         <li *ngFor="let rightLink of rightLinks">
-          <a
-            [id]="rightLink.routerLink"
+          <a [id]="rightLink.routerLink" *ngIf="!rightLink.onlySignedIn || (rightLink.onlySignedIn && isSignedIn)"
+            [routerLink]="rightLink.routerLink" routerLinkActive="active">
            [ngClass]="{'invisible': (( rightLink.onlySignedIn ||rightLink.onlySignedIn && !isSignedIn) || (rightLink.onlyOrganisationMember && !isOrganisationMember))}"
-            [routerLink]="rightLink.routerLink"
-            routerLinkActive="active"
-          >
-            <span class="far fa-bookmark" style="font-size: x-large"></span
-            ><span [mdmArrow]="rightLink.arrow"> {{ rightLink?.label }} </span>
+              rightLink?.label }} </span>
           </a>
         </li>
         <li>
-          <a
-            [id]="accountLink.routerLink"
+          <a [id]="accountLink.routerLink" *ngIf="!accountLink.onlySignedIn || (accountLink.onlySignedIn && isSignedIn)"
+            [routerLink]="accountLink.routerLink" routerLinkActive="active">
             [ngClass]="{'invisible': ((accountLink.onlySignedIn && !isSignedIn) || (accountLink.onlyOrganisationMember && !isOrganisationMember))}"
-            [routerLink]="accountLink.routerLink"
-            routerLinkActive="active"
-          >
             <span class="fas fa-cart-shopping" style="font-size: x-large"></span>
-            <span
-              *ngIf="draftDataSpecificationCount > 0"
-              class="mdm-header__links--data-specification-count"
-              >{{ draftDataSpecificationCount }}</span
-            >
+            <span *ngIf="draftDataSpecificationCount > 0" class="mdm-header__links--data-specification-count">{{
+              draftDataSpecificationCount }}</span>
             <span [mdmArrow]="accountLink.arrow"> {{ accountLink.label }} </span>
           </a>
         </li>
@@ -105,24 +86,11 @@ SPDX-License-Identifier: Apache-2.0
         </div>
         <div *ngIf="isSignedIn" class="mdm-header__user--sign-out">
           <a class="mdm-header__containOverlay" routerLink="/account">
-            <img
-              *ngIf="signedInUserProfileImageSrc"
-              [src]="signedInUserProfileImageSrc"
-              alt="User profile"
-              width="40"
-              height="40"
-            />
-            <img
-              *ngIf="!signedInUserProfileImageSrc"
-              src="assets/images/BlackDisk.svg"
-              alt="User profile"
-              width="40"
-              height="40"
-            />
-            <div
-              *ngIf="!signedInUserProfileImageSrc"
-              class="mdm-header__user--name mdm-header__overlayUserInitials"
-            >
+            <img *ngIf="signedInUserProfileImageSrc" [src]="signedInUserProfileImageSrc" alt="User profile" width="40"
+              height="40" />
+            <img *ngIf="!signedInUserProfileImageSrc" src="assets/images/BlackDisk.svg" alt="User profile" width="40"
+              height="40" />
+            <div *ngIf="!signedInUserProfileImageSrc" class="mdm-header__user--name mdm-header__overlayUserInitials">
               {{ signedInUser?.firstName?.charAt(0) }}{{ signedInUser?.lastName?.charAt(0) }}
             </div>
           </a>

--- a/src/app/shared/header/header.component.html
+++ b/src/app/shared/header/header.component.html
@@ -27,7 +27,10 @@ SPDX-License-Identifier: Apache-2.0
   </div>
   <div class="mdm-header__logo--align-right">
     <a [routerLink]="logoLink?.routerLink ?? ''">
-      <img [src]="logoLink?.customRightImageSrc || logoLink?.defaultRightImageSrc" [alt]="logoLink?.label" />
+      <img
+        [src]="logoLink?.customRightImageSrc || logoLink?.defaultRightImageSrc"
+        [alt]="logoLink?.label"
+      />
     </a>
   </div>
 </header>
@@ -35,9 +38,10 @@ SPDX-License-Identifier: Apache-2.0
   <div class="mdm-header__links">
     <nav class="mdm-header__links--main" role="navigation" aria-label="Site navigation">
       <ul>
-        <!-- Include a menu if there are links -->
         <li *ngFor="let link of links">
+          <ng-container *ngIf="link.menuLinks && link.menuLinks.length > 0; else noLinks">
             <a [ngClass]="{'invisible': ((link.onlySignedIn && !isSignedIn) || (link.onlyOrganisationMember && !isOrganisationMember))}"
+              routerLinkActive="active">
               <span [matMenuTriggerFor]="menu" style="cursor: pointer">{{ link.label }} <span [mdmArrow]="link.arrow">
                 </span></span>
             </a>
@@ -50,7 +54,8 @@ SPDX-License-Identifier: Apache-2.0
             </mat-menu>
           </ng-container>
           <ng-template #noLinks>
-            <a *ngIf="!link.onlySignedIn || (link.onlySignedIn && isSignedIn)" [routerLink]="link.routerLink"
+            <a [ngClass]="{'invisible': ((link.onlySignedIn && !isSignedIn) || (link.onlyOrganisationMember && !isOrganisationMember))}"
+              [routerLink]="link.routerLink"
               routerLinkActive="active">
               <span>{{ link.label }} <span [mdmArrow]="link.arrow"> </span></span>
             </a>
@@ -58,22 +63,37 @@ SPDX-License-Identifier: Apache-2.0
         </li>
       </ul>
     </nav>
-    <nav *ngIf="isSignedIn" class="mdm-header__links--right" role="navigation" aria-label="User navigation">
+    <nav
+      *ngIf="isSignedIn"
+      class="mdm-header__links--right"
+      role="navigation"
+      aria-label="User navigation"
+    >
       <ul>
         <li *ngFor="let rightLink of rightLinks">
-          <a [id]="rightLink.routerLink" *ngIf="!rightLink.onlySignedIn || (rightLink.onlySignedIn && isSignedIn)"
-            [routerLink]="rightLink.routerLink" routerLinkActive="active">
+          <a
+            [id]="rightLink.routerLink"
            [ngClass]="{'invisible': (( rightLink.onlySignedIn ||rightLink.onlySignedIn && !isSignedIn) || (rightLink.onlyOrganisationMember && !isOrganisationMember))}"
-              rightLink?.label }} </span>
+            [routerLink]="rightLink.routerLink"
+            routerLinkActive="active"
+          >
+            <span class="far fa-bookmark" style="font-size: x-large"></span
+            ><span [mdmArrow]="rightLink.arrow"> {{ rightLink?.label }} </span>
           </a>
         </li>
         <li>
-          <a [id]="accountLink.routerLink" *ngIf="!accountLink.onlySignedIn || (accountLink.onlySignedIn && isSignedIn)"
-            [routerLink]="accountLink.routerLink" routerLinkActive="active">
+          <a
+            [id]="accountLink.routerLink"
             [ngClass]="{'invisible': ((accountLink.onlySignedIn && !isSignedIn) || (accountLink.onlyOrganisationMember && !isOrganisationMember))}"
+            [routerLink]="accountLink.routerLink"
+            routerLinkActive="active"
+          >
             <span class="fas fa-cart-shopping" style="font-size: x-large"></span>
-            <span *ngIf="draftDataSpecificationCount > 0" class="mdm-header__links--data-specification-count">{{
-              draftDataSpecificationCount }}</span>
+            <span
+              *ngIf="draftDataSpecificationCount > 0"
+              class="mdm-header__links--data-specification-count"
+              >{{ draftDataSpecificationCount }}</span
+            >
             <span [mdmArrow]="accountLink.arrow"> {{ accountLink.label }} </span>
           </a>
         </li>
@@ -86,11 +106,24 @@ SPDX-License-Identifier: Apache-2.0
         </div>
         <div *ngIf="isSignedIn" class="mdm-header__user--sign-out">
           <a class="mdm-header__containOverlay" routerLink="/account">
-            <img *ngIf="signedInUserProfileImageSrc" [src]="signedInUserProfileImageSrc" alt="User profile" width="40"
-              height="40" />
-            <img *ngIf="!signedInUserProfileImageSrc" src="assets/images/BlackDisk.svg" alt="User profile" width="40"
-              height="40" />
-            <div *ngIf="!signedInUserProfileImageSrc" class="mdm-header__user--name mdm-header__overlayUserInitials">
+            <img
+              *ngIf="signedInUserProfileImageSrc"
+              [src]="signedInUserProfileImageSrc"
+              alt="User profile"
+              width="40"
+              height="40"
+            />
+            <img
+              *ngIf="!signedInUserProfileImageSrc"
+              src="assets/images/BlackDisk.svg"
+              alt="User profile"
+              width="40"
+              height="40"
+            />
+            <div
+              *ngIf="!signedInUserProfileImageSrc"
+              class="mdm-header__user--name mdm-header__overlayUserInitials"
+            >
               {{ signedInUser?.firstName?.charAt(0) }}{{ signedInUser?.lastName?.charAt(0) }}
             </div>
           </a>


### PR DESCRIPTION
*   Added "Home" menu item
*   "Moved" organisations page to top level menu — no longer available as a tab on the "Requests" page.  Did this by leaving the `Departments` component as-is and simply embedding it in a new `Organisations` component. 
*   Done the same with "Projects" as with organisations
*   The Requests page now only shows the requests and is no longer in a tab group. Have left the requests page in the `SdeMainComponent`—might benefit from a rename.
*   Not stated in the issue but have assumed the "Browse" and "Search" pages need to be removed after being put under the "Catalogue" menu.
*   Added a "Catalogue" tab which is a drop down menu offering "Browse" and "Search".  The menu is dropped down if any of the menu text is clicked on and does not navigate until an item is chosen.  This change also affects the "Help" menu which I think is consistent.

Closes #512
