### PR TITLE
gh-532: removed impersonate endpoint dependencies

### DIFF
--- a/src/app/security/security.service.spec.ts
+++ b/src/app/security/security.service.spec.ts
@@ -31,8 +31,6 @@ import {
 } from '../testing/stubs/mdm-endpoints.stub';
 import { setupTestModuleForService } from '../testing/testing.helpers';
 import {
-  AuthToken,
-  EMPTY_AUTH_TOKEN,
   OpenIdConnectConfiguration,
   OpenIdConnectSession,
   OPENID_CONNECT_CONFIG,
@@ -173,9 +171,7 @@ describe('SecurityService', () => {
 
   describe('sign out', () => {
     it('should sign out user', () => {
-      endpointsStub.security.logout.mockImplementationOnce(() =>
-        cold('--a|', { a: EMPTY })
-      );
+      endpointsStub.security.logout.mockImplementationOnce(() => cold('--a|', { a: EMPTY }));
 
       const expected$ = cold('--a|', { a: undefined });
       const actual$ = service.signOut();
@@ -196,34 +192,6 @@ describe('SecurityService', () => {
       expect(actual$).toSatisfyOnFlush(() => {
         expect(userDetailsStub.clear).toHaveBeenCalled();
       });
-    });
-  });
-
-  describe('sign in to sde', () => {
-    it('should sign in to sde', () => {
-      const emailAssociatedWithSDE = 'test@email.com';
-      const expected = { token: 'valid-token' } as AuthToken;
-
-      sdeUserServiceStub.getSdeAuthToken.mockReturnValueOnce(
-        cold('--a|', { a: expected })
-      );
-
-      const actual$ = service.signInToSde(emailAssociatedWithSDE);
-
-      expect(actual$).toBeObservable(cold('--a|', { a: expected }));
-    });
-
-    it('should return empty token if sde sign in fails', () => {
-      const emailNOTAssociatedWithSDE = 'test@email.com';
-      const expected = EMPTY_AUTH_TOKEN;
-
-      sdeUserServiceStub.getSdeAuthToken.mockReturnValueOnce(
-        cold('--#', new HttpErrorResponse({}))
-      );
-
-      const actual$ = service.signInToSde(emailNOTAssociatedWithSDE);
-
-      expect(actual$).toBeObservable(cold('--(a|)', { a: expected }));
     });
   });
 
@@ -254,24 +222,21 @@ describe('SecurityService', () => {
   });
 
   describe('isAuthenticated', () => {
-    it.each([true, false])(
-      'should return %o for an authenticated session',
-      (authenticated) => {
-        endpointsStub.session.isAuthenticated.mockImplementationOnce(() =>
-          cold('--a|', {
-            a: {
-              body: {
-                authenticatedSession: authenticated,
-              },
+    it.each([true, false])('should return %o for an authenticated session', (authenticated) => {
+      endpointsStub.session.isAuthenticated.mockImplementationOnce(() =>
+        cold('--a|', {
+          a: {
+            body: {
+              authenticatedSession: authenticated,
             },
-          })
-        );
+          },
+        })
+      );
 
-        const expected$ = cold('--a|', { a: authenticated });
-        const actual$ = service.isAuthenticated();
-        expect(actual$).toBeObservable(expected$);
-      }
-    );
+      const expected$ = cold('--a|', { a: authenticated });
+      const actual$ = service.isAuthenticated();
+      expect(actual$).toBeObservable(expected$);
+    });
 
     it('should throw error if authentication fails', () => {
       endpointsStub.session.isAuthenticated.mockImplementationOnce(() =>
@@ -294,10 +259,7 @@ describe('SecurityService', () => {
       };
 
       const expectedUrl = new URL(provider.authorizationEndpoint);
-      expectedUrl.searchParams.append(
-        'redirect_uri',
-        openIdConnectConfig.redirectUrl.toString()
-      );
+      expectedUrl.searchParams.append('redirect_uri', openIdConnectConfig.redirectUrl.toString());
 
       const actualUrl = service.getOpenIdConnectAuthorizationUrl(provider);
       expect(actualUrl).toEqual(expectedUrl);

--- a/src/app/security/security.service.ts
+++ b/src/app/security/security.service.ts
@@ -42,8 +42,6 @@ import { MdmEndpointsService } from '../mauro/mdm-endpoints.service';
 import { MdmHttpError } from '../mauro/mauro.types';
 import {
   AuthenticatedSessionError,
-  AuthToken,
-  EMPTY_AUTH_TOKEN,
   LoginError,
   OpenIdConnectConfiguration,
   OpenIdConnectSession,
@@ -108,17 +106,6 @@ export class SecurityService {
             return user;
           })
         );
-      })
-    );
-  }
-
-  signInToSde(email: string): Observable<AuthToken> {
-    return this.sdeUserService.getSdeAuthToken(email).pipe(
-      catchError((error: HttpErrorResponse): Observable<AuthToken> => {
-        console.log(`Status: ${error.status} | Message: ${error.message}`);
-
-        // If error, then print the error and set the token to the empty string.
-        return of(EMPTY_AUTH_TOKEN);
       })
     );
   }

--- a/src/app/testing/stubs/security.stub.ts
+++ b/src/app/testing/stubs/security.stub.ts
@@ -1,4 +1,3 @@
-import { Uuid } from '@maurodatamapper/mdm-resources';
 import { Observable } from 'rxjs';
 import { UserDetails } from 'src/app/security/user-details.service';
 
@@ -23,15 +22,11 @@ SPDX-License-Identifier: Apache-2.0
 export type SendResetPasswordLinkFn = (email: string) => Observable<boolean>;
 export type SendResetPasswordLinkMockedFn = jest.MockedFunction<SendResetPasswordLinkFn>;
 
-export type GetSdeAuthTokenFn = (email: string) => Observable<Uuid>;
-export type GetSdeAuthTokenMockedFn = jest.MockedFunction<GetSdeAuthTokenFn>;
-
 export type SecurityIsSignedInFn = () => boolean;
 export type SecurityIsSignedInMockedFn = jest.MockedFunction<SecurityIsSignedInFn>;
 
 export type SecurityGetSignedInUserFn = () => UserDetails | null;
-export type SecurityGetSignedInUserMockedFn =
-  jest.MockedFunction<SecurityGetSignedInUserFn>;
+export type SecurityGetSignedInUserMockedFn = jest.MockedFunction<SecurityGetSignedInUserFn>;
 
 export interface SecurityServiceStub {
   signIn: jest.Mock;
@@ -39,7 +34,6 @@ export interface SecurityServiceStub {
   getSignedInUser: SecurityGetSignedInUserMockedFn;
   sendResetPasswordLink: SendResetPasswordLinkMockedFn;
   getOpenIdConnectProviders: jest.Mock;
-  getSdeAuthToken: GetSdeAuthTokenMockedFn;
 }
 
 export const createSecurityServiceStub = (): SecurityServiceStub => {
@@ -49,6 +43,5 @@ export const createSecurityServiceStub = (): SecurityServiceStub => {
     getSignedInUser: jest.fn() as SecurityGetSignedInUserMockedFn,
     sendResetPasswordLink: jest.fn() as SendResetPasswordLinkMockedFn,
     getOpenIdConnectProviders: jest.fn(),
-    getSdeAuthToken: jest.fn() as GetSdeAuthTokenMockedFn,
   };
 };


### PR DESCRIPTION
Please test this with sde-resources issue 333 and sde-core issue 331 and sde-admin-ui issue 279.

An endpoint was removed from sde-core. this is a follow-up task.