### PR TITLE
More tweaks to work with mauro-micronaut

### DIFF
--- a/src/app/data-explorer/data-specification.service.ts
+++ b/src/app/data-explorer/data-specification.service.ts
@@ -296,9 +296,6 @@ export class DataSpecificationService {
       (dataElementInstance) => dataElementInstance as DataElementDto
     );
     return of(items).pipe(
-      switchMap((dataElements: DataElementDto[]) => {
-        return this.dataModels.elementsInAnotherModel(targetModel, dataElements);
-      }),
       switchMap((dataElements: DataElementDto[]) => from(dataElements)),
       filter((item) => item !== null),
       concatMap((item: DataElementDto) => {

--- a/src/app/shared/data-element-in-data-specification/data-element-in-data-specification.component.ts
+++ b/src/app/shared/data-element-in-data-specification/data-element-in-data-specification.component.ts
@@ -152,15 +152,7 @@ export class DataElementInDataSpecificationComponent implements OnInit, OnDestro
         caption: 'Updating your data specification...',
       });
 
-      this.explorer
-        .getRootDataModel()
-        .pipe(
-          switchMap((rootModel: DataModelDetail) => {
-            return this.dataModelService.elementsInAnotherModel(
-              rootModel,
-              this.dataElementSearchResultsToDataElementDTOs(dataElements)
-            );
-          }),
+      of(this.dataElementSearchResultsToDataElementDTOs(dataElements)).pipe(
           switchMap((rootDataElements) => {
             // Elements cannot be copied to themselves, so if the source and target model is the same,
             // use the root model as the source instead.


### PR DESCRIPTION
Remove unneeded path lookups. Looks like the DataElement IDs were already present so these weren't needed anyway.